### PR TITLE
Only call uname -m if java os.arch reports x86

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -70,6 +70,9 @@ class PlatformDetailsTask implements Callable<HashSet<String>, IOException> {
     }
 
     private String checkLinux32Bit(String arch) {
+        if (!"x86".equalsIgnoreCase(arch) || isWindows()) {
+            return arch;
+        }
         try {
             Process p = Runtime.getRuntime().exec("/bin/uname -m");
             p.waitFor();
@@ -127,5 +130,9 @@ class PlatformDetailsTask implements Callable<HashSet<String>, IOException> {
         result.add(name + "-" + version);
         result.add(arch + "-" + name + "-" + version);
         return result;
+    }
+
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -28,6 +28,23 @@ public class PlatformDetailsTaskTest {
         }
     }
 
+    @Test
+    public void testComputeLabelsLinux32Bit() throws Exception {
+        PlatformDetailsTask platformDetailsTask = new PlatformDetailsTask();
+        Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+        assertThat(details, not(hasItems("windows")));
+        String osName = System.getProperty("os.name", "os.name.is.unknown");
+        if (osName.toLowerCase().startsWith("linux")) {
+            assertThat(details, not(hasItems("linux")));
+            assertThat(details, not(hasItems("Linux")));
+            assertThat(details, anyOf(hasItems("Debian"), hasItems("CentOS"), hasItems("Ubuntu")));
+            // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
+            String expectedArch = System.getProperty("sun.arch.data.model", "23").equals("32") ? "x86" : "amd64";
+            // Assumes tests run in JVM that matches operating system
+            assertThat(details, hasItems(expectedArch));
+        }
+    }
+
     private boolean isWindows() {
         return File.pathSeparatorChar == ';';
     }


### PR DESCRIPTION
If java os.arch reports x86, there is a reasonable chance that the agent
is running a 32 bit JVM on a 64 bit (Windows) machine.  Avoid the call to
"uname -m" in other cases.

Yes, it is possible someone found a way to run a 32 bit JVM on a 64 bit
ARM configuration.  No, this does not support such a configuration.

## JENKINS-10383 - Wrong architecture reported if 32 bit Java on 64 bit platforms

Plugin seeks additional hints when the environment reports a 32 bit Java process, since it may be a 32 bit Java process executing on a 64 bit operating system.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/git-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
