### PR TITLE
Add alpine support

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -64,7 +64,9 @@ public class NodeLabelCache extends ComputerListener {
     refreshModel(computer);
   }
 
-  /** Caches the labels for the computer against its node.
+  /**
+   * Caches the labels for the computer against its node.
+   *
    * @param computer node whose labels will be cached
    * @throws IOException on I/O error
    * @throws InterruptedException on thread interruption
@@ -74,7 +76,9 @@ public class NodeLabelCache extends ComputerListener {
     nodeLabels.put(computer.getNode(), requestNodeLabels(computer));
   }
 
-  /** Update Jenkins' model so that labels for this computer are up to date.
+  /**
+   * Update Jenkins' model so that labels for this computer are up to date.
+   *
    * @param computer node whose labels will be cached
    */
   void refreshModel(final Computer computer) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -90,6 +90,14 @@ public class NodeLabelCache extends ComputerListener {
     }
   }
 
+  /**
+   * Return collection of labels for computer.
+   *
+   * @param computer agent whose labels are returned
+   * @throws IOException on I/O error
+   * @throws InterruptedException on thread interruption
+   * @return collection of labels for computer
+   */
   private Collection<LabelAtom> requestNodeLabels(Computer computer)
       throws IOException, InterruptedException {
     final VirtualChannel channel = computer.getChannel();

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -24,7 +24,9 @@ public class PlatformDetailsTaskTest {
     if (osName.toLowerCase().startsWith("linux")) {
       assertThat(details, not(hasItems("linux")));
       assertThat(details, not(hasItems("Linux")));
-      assertThat(details, anyOf(hasItems("Debian"), hasItems("CentOS"), hasItems("Ubuntu")));
+      assertThat(
+          details,
+          anyOf(hasItems("Alpine"), hasItems("Debian"), hasItems("CentOS"), hasItems("Ubuntu")));
     }
   }
 
@@ -37,7 +39,9 @@ public class PlatformDetailsTaskTest {
     if (osName.toLowerCase().startsWith("linux")) {
       assertThat(details, not(hasItems("linux")));
       assertThat(details, not(hasItems("Linux")));
-      assertThat(details, anyOf(hasItems("Debian"), hasItems("CentOS"), hasItems("Ubuntu")));
+      assertThat(
+          details,
+          anyOf(hasItems("Alpine"), hasItems("Debian"), hasItems("CentOS"), hasItems("Ubuntu")));
       // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
       String expectedArch =
           System.getProperty("sun.arch.data.model", "23").equals("32") ? "x86" : "amd64";


### PR DESCRIPTION
## [JENKINS-52798](https://issues.jenkins-ci.org/browse/JENKINS-52798) - Support Alpine Linux

Alpine Linux does not support the lsb_release command. The lsb_release command is used by the platformlabeler-plugin to determine the name of the Linux distributor. For example, it is used to determine CentOS, Debian, SUSE, and Ubuntu as Linux operating system distributions.

The platformlabeler plugin should support Alpine Linux since it is the basis of one of the three Jenkins Docker images and is increasingly the preferred image due to its small size.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No findbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Further comments

This plugin would benefit greatly from docker-fixtures tests.  It could then define a docker agent based on each of the following Linux variants to test operating system detection:

* Alpine
* CentOS 6
* CentOS 7
* Debian 8
* Debian 9
* Debian Testing
* OpenSUSE Leap
* OpenSUSE Tumbleweed
* Ubuntu 16
* Ubuntu 18

Until those tests can be written, I'll continue interactive testing of the various platforms.