### PR TITLE
Use Jenkins 2.152 as base jenkins version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.143</jenkins.version>
+    <jenkins.version>2.152</jenkins.version>
     <java.level>8</java.level>
   </properties>
 


### PR DESCRIPTION
## use Jenkins 2.152 - latest Java 11 changes

Latest Jenkins weekly version with latest Java 11 changes.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] No findbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
