### PR TITLE
More java 11 in jenkinsfile

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dfindbugs.skip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,12 @@
 #!groovy
 
 buildPlugin(configurations: [
-              [ platform: "linux",   jdk: "8",  jenkins: null ],
-              [ platform: "windows", jdk: "8",  jenkins: null ],
-              [ platform: "linux",   jdk: "8",  jenkins: "2.150.1", javaLevel: "8" ],
-              [ platform: "windows", jdk: "8",  jenkins: "2.150.1", javaLevel: "8" ],
-              [ platform: "linux",   jdk: "11", jenkins: "2.150.1", javaLevel: "8" ],
-              [ platform: "windows", jdk: "11", jenkins: "2.150.1", javaLevel: "8" ]
+              [ jdk:  "8", jenkins: null,    platform: "windows" ],
+              [ jdk:  "8", jenkins: null,    platform: "linux"   ],
+              [ jdk:  "8", jenkins: "2.154", platform: "windows" ],
+              [ jdk:  "8", jenkins: "2.154", platform: "linux"   ],
+              [ jdk: "11", jenkins: null,    platform: "windows" ],
+              [ jdk: "11", jenkins: null,    platform: "linux"   ],
+              [ jdk: "11", jenkins: "2.154", platform: "windows" ],
+              [ jdk: "11", jenkins: "2.154", platform: "linux"   ],
             ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
 #!groovy
 
-// test base Jenkins version
-buildPlugin(jenkinsVersions: [null],
-            jdkVersions: ['8', '11'],
-            findbugs: [run:true, archive:true, unstableTotalAll: '0'],
-            checkstyle: [run:true, archive:true, unstableTotalAll: '16'],
-            failFast: false)
+buildPlugin(configurations: [
+              [ platform: "linux",   jdk: "8",  jenkins: null ],
+              [ platform: "windows", jdk: "8",  jenkins: null ],
+              [ platform: "linux",   jdk: "8",  jenkins: "2.150.1", javaLevel: "8" ],
+              [ platform: "windows", jdk: "8",  jenkins: "2.150.1", javaLevel: "8" ],
+              [ platform: "linux",   jdk: "11", jenkins: "2.150.1", javaLevel: "8" ],
+              [ platform: "windows", jdk: "11", jenkins: "2.150.1", javaLevel: "8" ]
+            ])

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.154</jenkins.version>
+    <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 


### PR DESCRIPTION
## Use buildPlugin better for Java 11 support

Test more Java 8 and Java 11 configurations

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No findbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
