### PR TITLE
Add AmazonAMI to list of tested Linux variants

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -26,7 +26,12 @@ public class PlatformDetailsTaskTest {
       assertThat(details, not(hasItems("Linux")));
       assertThat(
           details,
-          anyOf(hasItems("Alpine"), hasItems("Debian"), hasItems("CentOS"), hasItems("Ubuntu")));
+          anyOf(
+              hasItems("Alpine"),
+              hasItems("AmazonAMI"),
+              hasItems("Debian"),
+              hasItems("CentOS"),
+              hasItems("Ubuntu")));
     }
   }
 
@@ -41,7 +46,12 @@ public class PlatformDetailsTaskTest {
       assertThat(details, not(hasItems("Linux")));
       assertThat(
           details,
-          anyOf(hasItems("Alpine"), hasItems("Debian"), hasItems("CentOS"), hasItems("Ubuntu")));
+          anyOf(
+              hasItems("Alpine"),
+              hasItems("AmazonAMI"),
+              hasItems("Debian"),
+              hasItems("CentOS"),
+              hasItems("Ubuntu")));
       // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
       String expectedArch =
           System.getProperty("sun.arch.data.model", "23").equals("32") ? "x86" : "amd64";


### PR DESCRIPTION
## Add AmazonAMI to test assertions - Amazon Linux LSB identifier

Allow tests to pass on Amazon Linux.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] No findbugs warnings were introduced with my changes

## Types of changes

- [x] Non-breaking change
