### PR TITLE
Use google checks in checkstyle and use latest checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.107.3</jenkins.version>
     <java.level>8</java.level>
+    <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
+    <maven.checkstyle.version>8.17</maven.checkstyle.version>
   </properties>
 
   <dependencies>
@@ -99,6 +101,22 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven.checkstyle.plugin.version}</version>
+	<dependencies>
+	  <dependency>
+	    <groupId>com.puppycrawl.tools</groupId>
+	    <artifactId>checkstyle</artifactId>
+	    <version>${maven.checkstyle.version}</version>
+	  </dependency>
+	</dependencies>
+        <configuration>
+          <configLocation>google_checks.xml</configLocation>
+          <failOnViolation>true</failOnViolation>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Use Google checks in checkstyle

Google code formatting is mandated by the formatting plugin. Use google checks for checkstyle as well.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No findbugs warnings were introduced with my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
