### PR TITLE
Don't add labels to a node without executors

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -62,8 +62,10 @@ public class NodeLabelCache extends ComputerListener {
   @Override
   public final void onOnline(final Computer computer, final TaskListener ignored)
       throws IOException, InterruptedException {
-    cacheLabels(computer);
-    refreshModel(computer);
+    if (computer.getNumExecutors() > 0) {
+      cacheLabels(computer);
+      refreshModel(computer);
+    }
   }
 
   /**


### PR DESCRIPTION
## Don't add labels to a node without executors

If I don't have any chance to execute something on a node, I don't need any labels to select that node for execution.

If I understand the javadoc correctly, this fixes only one edge case: It doesn't add labels to the master when it doesn't have any executors (which is strongly recommended nowadays) - for other nodes without executors there should be no `Computer` instance, so they should never have any labels anyways...

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [ ] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

I didn't add any test cases because I'm not quite sure how to test this change...
