### PR TITLE
Add javadoc to LsbRelease class

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import java.io.BufferedReader;
@@ -56,7 +57,7 @@ public class LsbRelease {
   }
 
   /**
-   * Return the Linux distributor ID for this agent
+   * Return the Linux distributor ID for this agent.
    *
    * @return Linux distributor ID for this agent
    */
@@ -65,7 +66,7 @@ public class LsbRelease {
   }
 
   /**
-   * Return the Linux release for this agent
+   * Return the Linux release for this agent.
    *
    * @return Linux release for this agent
    */

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -30,10 +30,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+/** Linux standard base release class. Provides distributor ID and release. */
 public class LsbRelease {
   private final String distributorId;
   private final String release;
 
+  /** Extract distributor ID and release for current platform. */
   public LsbRelease() {
     Map<String, String> newProps = new HashMap<>();
     try {
@@ -53,10 +55,20 @@ public class LsbRelease {
     this.release = newProps.get("Release");
   }
 
+  /**
+   * Return the Linux distributor ID for this agent
+   *
+   * @return Linux distributor ID for this agent
+   */
   public String distributorId() {
     return distributorId;
   }
 
+  /**
+   * Return the Linux release for this agent
+   *
+   * @return Linux release for this agent
+   */
   public String release() {
     return release;
   }


### PR DESCRIPTION
Easier to add the javadoc than fight checkstyle

Strange to add javadoc to a project that intentionally does not publish
javadoc, but easier than battling with checkstyle exclusions for checks
that don't make sense in this project.


## Add Javadoc to LsbRelease class

Easier to add the javadoc than fight checkstyle

It is a little strange to add javadoc to a project that intentionally does not publish javadoc, but easier than battling with checkstyle exclusions for checks that don't make sense in this project.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

- [x] non-breaking change