### PR TITLE
Simplify pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <name>Jenkins platformlabeler plugin</name>
   <description>Assigns labels to nodes based on their operating system properties</description>
-  <url>https://wiki.jenkins.io/display/JENKINS/PlatformLabeler+Plugin</url>
+  <url>https://plugins.jenkins.io/platformlabeler</url>
 
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -62,15 +62,6 @@
   </pluginRepositories>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>com.coveo</groupId>


### PR DESCRIPTION
## Simplify pom

Rely on the parent pom to provide the maven compiler plugin version.  Use the plugins site as the URL destination for plugin documentation rather than using the wiki.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Non-breaking change