### PR TITLE
Improve NodeLabelCache test coverage

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -4,14 +4,25 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import hudson.model.Computer;
+import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
+import hudson.remoting.VirtualChannel;
+import hudson.slaves.RetentionStrategy;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.logging.LogRecord;
+import javax.servlet.ServletException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * Test NodeLabelCache in a few potential error cases.
@@ -60,5 +71,73 @@ public class NodeLabelCacheTest {
   @Test
   public void testRefreshModelNullComputer() {
     nodeLabelCache.refreshModel(null);
+  }
+
+  @Test
+  public void testRefreshModelNullingComputer() {
+    Computer nullingComputer = new NullingComputer(computer.getNode());
+    nodeLabelCache.refreshModel(nullingComputer);
+  }
+
+  @Test(expected = IOException.class)
+  public void testCacheLabelsNullingComputer() throws Exception {
+    Computer nullingComputer = new NullingComputer(computer.getNode());
+    nodeLabelCache.cacheLabels(nullingComputer);
+  }
+
+  /** Class that intentionally returns nulls for test purposes. */
+  private class NullingComputer extends Computer {
+
+    public NullingComputer(Node node) {
+      super(node);
+    }
+
+    @Override
+    public Node getNode() {
+      /* Intentionally return null to test null node handling */
+      return null;
+    }
+
+    @Override
+    public VirtualChannel getChannel() {
+      /* Intentionally return null to test null channel handling */
+      return null;
+    }
+
+    @Override
+    public Charset getDefaultCharset() {
+      throw new UnsupportedOperationException("Unsupported");
+    }
+
+    @Override
+    public List<LogRecord> getLogRecords() throws IOException, InterruptedException {
+      throw new UnsupportedOperationException("Unsupported");
+    }
+
+    @Override
+    public void doLaunchSlaveAgent(StaplerRequest sr, StaplerResponse sr1)
+        throws IOException, ServletException {
+      throw new UnsupportedOperationException("Unsupported");
+    }
+
+    @Override
+    protected Future<?> _connect(boolean bln) {
+      throw new UnsupportedOperationException("Unsupported");
+    }
+
+    @Override
+    public Boolean isUnix() {
+      throw new UnsupportedOperationException("Unsupported");
+    }
+
+    @Override
+    public boolean isConnecting() {
+      throw new UnsupportedOperationException("Unsupported");
+    }
+
+    @Override
+    public RetentionStrategy getRetentionStrategy() {
+      throw new UnsupportedOperationException("Unsupported");
+    }
   }
 }


### PR DESCRIPTION
## Improve NodeLabel test coverage

Test two failure cases, one when a node has been reconfigured and not yet saved, the other when the node's communication channel is null.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Non-breaking change