### PR TITLE
Fix Amazon Linux fallback identifier

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!groovy
 
-// Use recommended configuration
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+// Use recommended configuration, run all tests to completion (don't fail fast)
+buildPlugin(configurations: buildPlugin.recommendedConfigurations(),
+            failFast: false)

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -200,8 +200,7 @@ class PlatformDetailsTask implements Callable<HashSet<String>, IOException> {
 
   static {
     PREFERRED_LINUX_OS_NAMES.put("alpine", "Alpine");
-    PREFERRED_LINUX_OS_NAMES.put("amazon", "Amazon");
-    PREFERRED_LINUX_OS_NAMES.put("amazonami", "AmazonAMI");
+    PREFERRED_LINUX_OS_NAMES.put("amzn", "Amazon");
     PREFERRED_LINUX_OS_NAMES.put("centos", "CentOS");
     PREFERRED_LINUX_OS_NAMES.put("debian", "Debian");
     PREFERRED_LINUX_OS_NAMES.put("opensuse", "openSUSE");


### PR DESCRIPTION
## Fix Amazon Linux fallback identifier

If Amazon Linux was used without installing lsb_release, it would report the operating system incorrectly.  The /etc/os-release ID value is 'amzn', so the mapping table is being updated for that correct value.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)