### PR TITLE
Use Azure Container Instances

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 #!groovy
 
-// Use recommended configuration, run all tests to completion (don't fail fast)
+// Use recommended configuration,
+// run all tests to completion (don't immediately fail entire job if tests fail), and
+// run on Azure Container Instances (ACI) for the Linux portion of the build
+
 buildPlugin(configurations: buildPlugin.recommendedConfigurations(),
-            failFast: false)
+            failFast: false,
+            useAci: true)


### PR DESCRIPTION
## Use Azure Container Instances for CI

Azure Container Instances use a container for agents in the build. The agents are created and destroyed as part of the job.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure