### PR TITLE
Evaluate newer LTS in addition to first JDK 11 LTS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,12 @@
 #!groovy
 
-// Use recommended configuration, run all tests to completion (don't fail fast)
-buildPlugin(configurations: buildPlugin.recommendedConfigurations(),
-            failFast: false)
+Random random = new Random() // Randomize which Jenkins version is selected for more testing
+use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
+
+// build recommended configurations
+subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                      ],
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins: use_newer_jenkins ? '2.176.3' : '2.164.1', javaLevel: '8' ]
+                      ]
+
+buildPlugin(configurations: subsetConfiguration, failFast: false)


### PR DESCRIPTION
## Evaluate newer LTS in addition to first JDK 11 LTS

Intentionally reduces tested configurations and accepts that some checks are skipped in order to reduce resource use.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure

If this is a relatively large or complex change, start the discussion by explaining why you chose the solution you did and what alternatives you considered.