### PR TITLE
Provide plugin documentation from GitHub README

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <name>Jenkins platformlabeler plugin</name>
   <description>Assigns labels to nodes based on their operating system properties</description>
-  <url>https://plugins.jenkins.io/platformlabeler</url>
+  <url>https://github.com/jenkinsci/platformlabeler-plugin</url>
 
   <developers>
     <developer>


### PR DESCRIPTION
## Plugin site docs from GitHub README

Stop relying on the wiki page for docs on plugins.jenkins.io.  Use GitHub README instead.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure

