### PR TITLE
Require Jenkins 2.164.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,14 @@ Please don't introduce new spotbugs output.
 ## Code Formatting
 
 Code formatting in the Platform Labeler plugin is maintained by fmt.
+The pom file format is maintained by the tidy plugin.
 Before submitting a pull request, confirm the formatting is correct with:
 
 * `mvn compile`
 
 If the formatting is not correct, the build will fail.  Correct the formatting with:
 
-* `mvn fmt:format`
+* `mvn tidy:pom fmt:format`
 
 ## Pre-commit Hooks
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Labels commonly include operating system name, version, and architecture.
 | Amazon Linux 2   | `2` `Amazon` `Amazon-2` `amd64` `amd64-Amazon` `amd64-Amazon-2`                                      |
 | CentOS 6         | `6.10` `CentOS` `CentOS-6.10` `amd64` `amd64-CentOS` `amd64-CentOS-6.10`                             |
 | CentOS 7         | `7.4.1708` `CentOS` `CentOS-7.4.1708` `amd64` `amd64-CentOS` `amd64-CentOS-7.4.1708`                 |
-| Debian 9         | `9.6` `Debian` `Debian-9.6` `amd64` `amd64-Debian` `amd64-Debian-9.6`                                |
+| Debian 9         | `9.11` `Debian` `Debian-9.11` `amd64` `amd64-Debian` `amd64-Debian-9.11`                             |
 | Debian 10        | `10` `Debian` `Debian-10` `amd64` `amd64-Debian` `amd64-Debian-10`                                   |
 | FreeBSD 11       | `11.1-STABLE` `amd64` `amd64-freebsd` `amd64-freebsd-11.1-STABLE` `freebsd` `freebsd-11.1-STABLE`    |
 | FreeBSD 12       | `12.0-RELEASE` `amd64` `amd64-freebsd` `amd64-freebsd-12.0-RELEASE` `freebsd` `freebsd-12.0-RELEASE` |

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.49</version>
+    <version>3.50</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
   <artifactId>platformlabeler</artifactId>
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
-  <inceptionYear>2009</inceptionYear>
 
   <name>Jenkins platformlabeler plugin</name>
   <description>Assigns labels to nodes based on their operating system properties</description>
   <url>https://github.com/jenkinsci/platformlabeler-plugin</url>
+  <inceptionYear>2009</inceptionYear>
 
   <developers>
     <developer>
@@ -47,6 +47,32 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.164.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -59,32 +85,6 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <dependencies>
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-  </dependencies>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom</artifactId>
-        <version>2.164.2</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>3.1.12</version>
       <optional>true</optional>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
@@ -88,6 +87,20 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>tidy-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,6 @@
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
     <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
-    <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
-    <maven.checkstyle.version>8.24</maven.checkstyle.version>
     <linkXRef>false</linkXRef>
     <!-- This plugin intentionally does not deliver javadoc. -->
     <!-- No API's intended to be used, none should be called from outside. -->
@@ -106,14 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${maven.checkstyle.plugin.version}</version>
-	<dependencies>
-	  <dependency>
-	    <groupId>com.puppycrawl.tools</groupId>
-	    <artifactId>checkstyle</artifactId>
-	    <version>${maven.checkstyle.version}</version>
-	  </dependency>
-	</dependencies>
+        <version>3.1.0</version>
         <configuration>
           <configLocation>google_checks.xml</configLocation>
           <failOnViolation>true</failOnViolation>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,18 @@
     </dependency>
   </dependencies>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.164.2</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.150.1</jenkins.version>
+    <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
     <maven.checkstyle.version>8.24</maven.checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
 
   <build>
     <plugins>
+      <!-- Fail build on pom formatting errors -->
+      <!-- Fix with mvn tidy:pom -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>tidy-maven-plugin</artifactId>
@@ -101,6 +103,8 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Fail build on Java formatting errors -->
+      <!-- Fix with mvn fmt:format -->
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>


### PR DESCRIPTION
## Require Jenkins 2.164.3, use plugin BOM

Require Jenkins 2.164.3 and use the matching plugin BOM for versions.
Enforce pom formatting with the tidy plugin.
Update the documentation for most recent versions of operating systems.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure