### PR TITLE
Improve name and description for search on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
-  <name>Jenkins platformlabeler plugin</name>
-  <description>Assigns labels to nodes based on their operating system properties</description>
+  <name>Jenkins platform labeler plugin</name>
+  <description>Labels agents based on their operating system (platform) version and architecture</description>
   <url>https://github.com/jenkinsci/platformlabeler-plugin</url>
   <inceptionYear>2009</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,6 @@
       <artifactId>reflections</artifactId>
       <version>0.9.11</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
## Improve name and description for search on plugins.jenkins.io

Searching plugins.jenkins.io for 'platform' does not detect this plugin.  The search must use the complete plugin name 'platformlabeler'.  Better to help users find it by using the word platform in name and description.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure