### PR TITLE
[JENKINS-17904] Allow to configure labels per node

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ For example:
 | Platform                     | Operating System   | Version        | Platform |
 | ---------------------------- | ------------------ | -------------- | -------- |
 | CentOS 7                     | `CentOS`           | `7`            | `amd64`  |
+
+It can be configured globally and per agent which labels should be generated. 
+To define for an agent, just check 'Automatic Platform Labels' and select the labels you want.

--- a/README.md
+++ b/README.md
@@ -37,5 +37,6 @@ For example:
 | ---------------------------- | ------------------ | -------------- | -------- |
 | CentOS 7                     | `CentOS`           | `7`            | `amd64`  |
 
-It can be configured globally and per agent which labels should be generated. 
-To define for an agent, just check 'Automatic Platform Labels' and select the labels you want.
+
+One can configure globally and per agent which labels should be generated. 
+To define the labels for an agent, just check 'Automatic Platform Labels' in the Node Properties section and select the labels you want to have.

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
@@ -1,0 +1,80 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/** Stores configuration about labels to generate */
+public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
+
+  private boolean architecture = true;
+  private boolean name = true;
+  private boolean version = true;
+  private boolean architectureName = true;
+  private boolean nameVersion = true;
+  private boolean architectureNameVersion = true;
+
+  @DataBoundConstructor
+  public LabelConfig() {}
+
+  public boolean isArchitecture() {
+    return architecture;
+  }
+
+  @DataBoundSetter
+  public void setArchitecture(boolean arch) {
+    this.architecture = arch;
+  }
+
+  public boolean isName() {
+    return name;
+  }
+
+  @DataBoundSetter
+  public void setName(boolean name) {
+    this.name = name;
+  }
+
+  public boolean isVersion() {
+    return version;
+  }
+
+  @DataBoundSetter
+  public void setVersion(boolean version) {
+    this.version = version;
+  }
+
+  public boolean isArchitectureName() {
+    return architectureName;
+  }
+
+  @DataBoundSetter
+  public void setArchitectureName(boolean archName) {
+    this.architectureName = archName;
+  }
+
+  public boolean isNameVersion() {
+    return nameVersion;
+  }
+
+  @DataBoundSetter
+  public void setNameVersion(boolean nameVersion) {
+    this.nameVersion = nameVersion;
+  }
+
+  public boolean isArchitectureNameVersion() {
+    return architectureNameVersion;
+  }
+
+  @DataBoundSetter
+  public void setArchitectureNameVersion(boolean archNameVersion) {
+    this.architectureNameVersion = archNameVersion;
+  }
+
+  @Extension
+  @Symbol("platformlabelerconfig")
+  public static class DescriptorImpl extends Descriptor<LabelConfig> {}
+}

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -92,7 +92,7 @@ public class NodeLabelCache extends ComputerListener {
    */
   final void cacheLabels(final Computer computer) throws IOException, InterruptedException {
     /* Cache the labels for the node */
-    nodePlatformProperties.put(computer, requestComputerOSProperties(computer));
+    nodePlatformProperties.put(computer, requestComputerPlatformDetails(computer));
   }
 
   /**
@@ -111,15 +111,15 @@ public class NodeLabelCache extends ComputerListener {
   }
 
   /**
-   * Return a Map of the properties of the OS of the node
+   * Return PlatformDetails of the computer.
    *
-   * @param computer agent whose labels are returned
-   * @return collection of labels for computer
+   * @param computer agent whose platform details are returned
+   * @return PlatformDeatils for computer
    * @throws IOException on I/O error
    * @throws InterruptedException on thread interruption
    */
   @NonNull
-  private PlatformDetails requestComputerOSProperties(final Computer computer)
+  private PlatformDetails requestComputerPlatformDetails(final Computer computer)
       throws IOException, InterruptedException {
     final VirtualChannel channel = computer.getChannel();
     if (null == channel) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -119,7 +119,7 @@ public class NodeLabelCache extends ComputerListener {
    * @throws InterruptedException on thread interruption
    */
   @NonNull
-  private PlatformDetails requestComputerPlatformDetails(final Computer computer)
+  PlatformDetails requestComputerPlatformDetails(final Computer computer)
       throws IOException, InterruptedException {
     final VirtualChannel channel = computer.getChannel();
     if (null == channel) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -1,0 +1,49 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import java.io.Serializable;
+
+/** Stores the platform details of a node */
+public class PlatformDetails implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String name;
+  private final String architecture;
+  private final String version;
+  private final String architectureNameVersion;
+  private final String architectureName;
+  private final String nameVersion;
+
+  public PlatformDetails(String name, String architecture, String version) {
+    this.name = name;
+    this.architecture = architecture;
+    this.version = version;
+    architectureNameVersion = architecture + "-" + name + "-" + version;
+    architectureName = architecture + "-" + name;
+    nameVersion = name + "-" + version;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getArchitecture() {
+    return architecture;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getArchitectureNameVersion() {
+    return architectureNameVersion;
+  }
+
+  public String getArchitectureName() {
+    return architectureName;
+  }
+
+  public String getNameVersion() {
+    return nameVersion;
+  }
+}

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
@@ -1,0 +1,43 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import hudson.Extension;
+import hudson.slaves.ComputerListener;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * Allows to configure which labels should be generate for the node when no node specific
+ * configuration is used.
+ */
+@Extension
+public class PlatformLabelerGlobalConfiguration extends GlobalConfiguration {
+
+  private LabelConfig labelConfig;
+
+  public PlatformLabelerGlobalConfiguration() {
+    load();
+    if (labelConfig == null) {
+      labelConfig = new LabelConfig();
+    }
+  }
+
+  @Override
+  public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+    boolean result = super.configure(req, json);
+    NodeLabelCache nlc = ComputerListener.all().get(NodeLabelCache.class);
+    if (nlc != null) {
+      nlc.onConfigurationChange();
+    }
+    return result;
+  }
+
+  public LabelConfig getLabelConfig() {
+    return labelConfig;
+  }
+
+  public void setLabelConfig(LabelConfig labelConfig) {
+    this.labelConfig = labelConfig;
+    save();
+  }
+}

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty.java
@@ -1,0 +1,35 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import hudson.Extension;
+import hudson.model.Node;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/** Allows to configure which labels should be generate for the node. */
+public class PlatformLabelerNodeProperty extends NodeProperty<Node> {
+
+  private LabelConfig labelConfig;
+
+  @DataBoundConstructor
+  public PlatformLabelerNodeProperty() {}
+
+  public LabelConfig getLabelConfig() {
+    return labelConfig;
+  }
+
+  @DataBoundSetter
+  public void setLabelConfig(LabelConfig labelConfig) {
+    this.labelConfig = labelConfig;
+  }
+
+  @Extension
+  public static class DescriptorImpl extends NodePropertyDescriptor {
+
+    @Override
+    public String getDisplayName() {
+      return "Automatic Platform Labels";
+    }
+  }
+}

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry field="architecture" title="Generate label with OS architecture">
+    <f:checkbox default="true"/>
+  </f:entry>
+  <f:entry field="name" title="Generate label with OS name">
+    <f:checkbox default="true"/>
+  </f:entry>
+  <f:entry field="version" title="Generate label with OS version">
+    <f:checkbox default="true"/>
+  </f:entry>
+  <f:entry field="architectureName" title="Generate label with OS architecture and name">
+    <f:checkbox default="true"/>
+  </f:entry>
+  <f:entry field="nameVersion" title="Generate label with OS name and version">
+    <f:checkbox default="true"/>
+  </f:entry>
+  <f:entry field="architectureNameVersion" title="Generate label with OS architecture, name and version">
+    <f:checkbox default="true"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-architecture.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-architecture.html
@@ -1,0 +1,1 @@
+Generate label with the OS architecture, e.g. 'amd64'.

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-architectureName.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-architectureName.html
@@ -1,0 +1,1 @@
+Generate label with the OS architecture and name, e.g. 'amd64-Ubuntu'.

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-architectureNameVersion.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-architectureNameVersion.html
@@ -1,0 +1,1 @@
+Generate label with the OS architecture, name and version, e.g. 'amd64-Ubuntu-18.04'.

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-name.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-name.html
@@ -1,0 +1,1 @@
+Generate label with the OS name, e.g. 'Ubuntu'.

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-nameVersion.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-nameVersion.html
@@ -1,0 +1,1 @@
+Generate label with the OS name and version, e.g. 'Ubuntu-18.04'.

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-version.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/help-version.html
@@ -1,0 +1,1 @@
+Generate label with the OS version, e.g. '18.04'.

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:section title="${%Platform Labeler}">
+    <f:property field="labelConfig"/>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<f:block>
+<table width="100%" style="padding-left:20px">
+  <f:property field="labelConfig"/>
+  </table>
+  </f:block>
+</j:jelly>

--- a/src/main/webapp/help-globalConfig.html
+++ b/src/main/webapp/help-globalConfig.html
@@ -1,5 +1,0 @@
-<div>
-  <p>
-    <!-- See help-projectConfig.html for more about what these HTMLs do. -->
-  </p>
-</div>

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.*;
 import hudson.model.Computer;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.ComputerListener;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 import jenkins.model.GlobalConfiguration;
 import org.junit.Before;
@@ -18,15 +21,17 @@ public class ConfigurationTest {
 
   private Computer computer;
   private NodeLabelCache nodeLabelCache;
+  private PlatformDetails platformDetails;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException, InterruptedException {
     computer = r.jenkins.toComputer();
     nodeLabelCache = ComputerListener.all().get(NodeLabelCache.class);
+    platformDetails = nodeLabelCache.requestComputerPlatformDetails(computer);
   }
 
   @Test
-  public void configuredOnlyOneLabel() {
+  public void configuredNameOnlyLabel() {
     PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
     LabelConfig labelConfig = new LabelConfig();
     labelConfig.setArchitecture(false);
@@ -38,8 +43,13 @@ public class ConfigurationTest {
     r.jenkins.getNodeProperties().add(nodeProperty);
 
     nodeLabelCache.onConfigurationChange();
+
+    Collection<LabelAtom> expected = new HashSet<>();
+    expected.add(r.jenkins.getLabelAtom("master"));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
+
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(labelsAfter.size(), is(2));
+    assertEquals(expected, labelsAfter);
   }
 
   @Test
@@ -54,21 +64,36 @@ public class ConfigurationTest {
     r.jenkins.getNodeProperties().add(nodeProperty);
 
     nodeLabelCache.onConfigurationChange();
+
+    Collection<LabelAtom> expected = new HashSet<>();
+    expected.add(r.jenkins.getLabelAtom("master"));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
+
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(nodeLabelCache.getLabelsForNode(computer.getNode()).size(), is(2));
-    assertThat(labelsAfter.size(), is(3));
+    assertEquals(expected, labelsAfter);
   }
 
   @Test
-  public void configuredAllLabels() {
+  public void configuredAllLabelsOnNode() {
     PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
     LabelConfig labelConfig = new LabelConfig();
     nodeProperty.setLabelConfig(labelConfig);
     r.jenkins.getNodeProperties().add(nodeProperty);
 
     nodeLabelCache.onConfigurationChange();
+
+    Collection<LabelAtom> expected = new HashSet<>();
+    expected.add(r.jenkins.getLabelAtom("master"));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureName()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
+
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(labelsAfter.size(), is(7));
+    assertEquals(expected, labelsAfter);
   }
 
   @Test
@@ -91,8 +116,42 @@ public class ConfigurationTest {
     r.jenkins.getNodeProperties().add(nodeProperty);
 
     nodeLabelCache.onConfigurationChange();
+
+    Collection<LabelAtom> expected = new HashSet<>();
+    expected.add(r.jenkins.getLabelAtom("master"));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureName()));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
+
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(nodeLabelCache.getLabelsForNode(computer.getNode()).size(), is(5));
-    assertThat(labelsAfter.size(), is(6));
+    assertEquals(expected, labelsAfter);
+  }
+
+  @Test
+  public void globalConfigOnlyArchitecture() {
+
+    PlatformLabelerGlobalConfiguration globalConfig =
+        GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
+
+    LabelConfig globalLabelConfig = new LabelConfig();
+
+    globalLabelConfig.setVersion(false);
+    globalLabelConfig.setName(false);
+    globalLabelConfig.setArchitectureName(false);
+    globalLabelConfig.setArchitectureNameVersion(false);
+    globalLabelConfig.setNameVersion(false);
+
+    globalConfig.setLabelConfig(globalLabelConfig);
+
+    nodeLabelCache.onConfigurationChange();
+
+    Collection<LabelAtom> expected = new HashSet<>();
+    expected.add(r.jenkins.getLabelAtom("master"));
+    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+
+    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+    assertEquals(expected, labelsAfter);
   }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -1,7 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import hudson.model.Computer;
 import hudson.model.labels.LabelAtom;
@@ -39,7 +39,6 @@ public class ConfigurationTest {
 
     nodeLabelCache.onConfigurationChange();
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    System.err.println(labelsAfter);
     assertThat(labelsAfter.size(), is(2));
   }
 
@@ -56,7 +55,6 @@ public class ConfigurationTest {
 
     nodeLabelCache.onConfigurationChange();
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    System.err.println(labelsAfter);
     assertThat(nodeLabelCache.getLabelsForNode(computer.getNode()).size(), is(2));
     assertThat(labelsAfter.size(), is(3));
   }
@@ -70,7 +68,6 @@ public class ConfigurationTest {
 
     nodeLabelCache.onConfigurationChange();
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    System.err.println(labelsAfter);
     assertThat(labelsAfter.size(), is(7));
   }
 
@@ -95,7 +92,6 @@ public class ConfigurationTest {
 
     nodeLabelCache.onConfigurationChange();
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    System.err.println(labelsAfter);
     assertThat(nodeLabelCache.getLabelsForNode(computer.getNode()).size(), is(5));
     assertThat(labelsAfter.size(), is(6));
   }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -1,0 +1,102 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import hudson.model.Computer;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.ComputerListener;
+import java.util.Set;
+import jenkins.model.GlobalConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ConfigurationTest {
+  @Rule public final JenkinsRule r = new JenkinsRule();
+
+  private Computer computer;
+  private NodeLabelCache nodeLabelCache;
+
+  @Before
+  public void setUp() {
+    computer = r.jenkins.toComputer();
+    nodeLabelCache = ComputerListener.all().get(NodeLabelCache.class);
+  }
+
+  @Test
+  public void configuredOnlyOneLabel() {
+    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+    LabelConfig labelConfig = new LabelConfig();
+    labelConfig.setArchitecture(false);
+    labelConfig.setArchitectureName(false);
+    labelConfig.setArchitectureNameVersion(false);
+    labelConfig.setVersion(false);
+    labelConfig.setNameVersion(false);
+    nodeProperty.setLabelConfig(labelConfig);
+    r.jenkins.getNodeProperties().add(nodeProperty);
+
+    nodeLabelCache.onConfigurationChange();
+    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+    System.err.println(labelsAfter);
+    assertThat(labelsAfter.size(), is(2));
+  }
+
+  @Test
+  public void configuredTwoLabels() {
+    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+    LabelConfig labelConfig = new LabelConfig();
+    labelConfig.setArchitectureName(false);
+    labelConfig.setArchitectureNameVersion(false);
+    labelConfig.setName(false);
+    labelConfig.setNameVersion(false);
+    nodeProperty.setLabelConfig(labelConfig);
+    r.jenkins.getNodeProperties().add(nodeProperty);
+
+    nodeLabelCache.onConfigurationChange();
+    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+    System.err.println(labelsAfter);
+    assertThat(nodeLabelCache.getLabelsForNode(computer.getNode()).size(), is(2));
+    assertThat(labelsAfter.size(), is(3));
+  }
+
+  @Test
+  public void configuredAllLabels() {
+    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+    LabelConfig labelConfig = new LabelConfig();
+    nodeProperty.setLabelConfig(labelConfig);
+    r.jenkins.getNodeProperties().add(nodeProperty);
+
+    nodeLabelCache.onConfigurationChange();
+    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+    System.err.println(labelsAfter);
+    assertThat(labelsAfter.size(), is(7));
+  }
+
+  @Test
+  public void nodeConfigOverridesGlobalConfig() {
+
+    PlatformLabelerGlobalConfiguration globalConfig =
+        GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
+
+    LabelConfig globalLabelConfig = new LabelConfig();
+
+    globalLabelConfig.setVersion(false);
+    globalLabelConfig.setArchitecture(false);
+
+    globalConfig.setLabelConfig(globalLabelConfig);
+
+    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+    LabelConfig labelConfig = new LabelConfig();
+    labelConfig.setVersion(false);
+    nodeProperty.setLabelConfig(labelConfig);
+    r.jenkins.getNodeProperties().add(nodeProperty);
+
+    nodeLabelCache.onConfigurationChange();
+    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+    System.err.println(labelsAfter);
+    assertThat(nodeLabelCache.getLabelsForNode(computer.getNode()).size(), is(5));
+    assertThat(labelsAfter.size(), is(6));
+  }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -1,7 +1,11 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
 
 import hudson.model.Computer;
 import hudson.model.Node;

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -1,11 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isIn;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import hudson.model.Computer;
 import hudson.model.Node;

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -1,13 +1,13 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.junit.Test;
@@ -62,16 +62,15 @@ public class PlatformDetailsTaskLsbReleaseTest {
     File lsbReleaseFile = new File(resource.toURI());
     assertTrue("File not found " + lsbReleaseFile, lsbReleaseFile.exists());
     LsbRelease release = new LsbRelease(lsbReleaseFile);
-    HashSet<String> result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
+    PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
+    assertThat(result.getArchitecture(), equalTo(expectedArch));
+    assertThat(result.getName(), equalTo(expectedName));
+    assertThat(result.getVersion(), equalTo(expectedVersion));
+    assertThat(result.getArchitectureName(), equalTo(expectedArch + "-" + expectedName));
     assertThat(
-        result,
-        containsInAnyOrder(
-            expectedArch,
-            expectedName,
-            expectedVersion,
-            expectedArch + "-" + expectedName,
-            expectedName + "-" + expectedVersion,
-            expectedArch + "-" + expectedName + "-" + expectedVersion));
+        result.getArchitectureNameVersion(),
+        equalTo(expectedArch + "-" + expectedName + "-" + expectedVersion));
+    assertThat(result.getNameVersion(), equalTo(expectedName + "-" + expectedVersion));
   }
 
   private static String computeExpectedName(String filename) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -1,8 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.net.URL;
@@ -63,14 +62,13 @@ public class PlatformDetailsTaskLsbReleaseTest {
     assertTrue("File not found " + lsbReleaseFile, lsbReleaseFile.exists());
     LsbRelease release = new LsbRelease(lsbReleaseFile);
     PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
-    assertThat(result.getArchitecture(), equalTo(expectedArch));
-    assertThat(result.getName(), equalTo(expectedName));
-    assertThat(result.getVersion(), equalTo(expectedVersion));
-    assertThat(result.getArchitectureName(), equalTo(expectedArch + "-" + expectedName));
+    assertThat(result.getArchitecture(), is(expectedArch));
+    assertThat(result.getName(), is(expectedName));
+    assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
     assertThat(
         result.getArchitectureNameVersion(),
-        equalTo(expectedArch + "-" + expectedName + "-" + expectedVersion));
-    assertThat(result.getNameVersion(), equalTo(expectedName + "-" + expectedVersion));
+        is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+    assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
   }
 
   private static String computeExpectedName(String filename) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -1,13 +1,13 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.junit.Test;
@@ -71,16 +71,15 @@ public class PlatformDetailsTaskReleaseTest {
     }
     String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     LsbRelease release = new LsbRelease(unknown, unknown);
-    HashSet<String> result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
+    PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
+    assertThat(result.getName(), equalTo(expectedName));
+    assertThat(result.getArchitecture(), equalTo(expectedArch));
+    assertThat(result.getVersion(), equalTo(expectedVersion));
+    assertThat(result.getArchitectureName(), equalTo(expectedArch + "-" + expectedName));
     assertThat(
-        result,
-        containsInAnyOrder(
-            expectedArch,
-            expectedName,
-            expectedVersion,
-            expectedArch + "-" + expectedName,
-            expectedName + "-" + expectedVersion,
-            expectedArch + "-" + expectedName + "-" + expectedVersion));
+        result.getArchitectureNameVersion(),
+        equalTo(expectedArch + "-" + expectedName + "-" + expectedVersion));
+    assertThat(result.getNameVersion(), equalTo(expectedName + "-" + expectedVersion));
   }
 
   private static String computeExpectedName(String filename) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -1,8 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.net.URL;
@@ -72,14 +71,14 @@ public class PlatformDetailsTaskReleaseTest {
     String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     LsbRelease release = new LsbRelease(unknown, unknown);
     PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
-    assertThat(result.getName(), equalTo(expectedName));
-    assertThat(result.getArchitecture(), equalTo(expectedArch));
-    assertThat(result.getVersion(), equalTo(expectedVersion));
-    assertThat(result.getArchitectureName(), equalTo(expectedArch + "-" + expectedName));
+    assertThat(result.getName(), is(expectedName));
+    assertThat(result.getArchitecture(), is(expectedArch));
+    assertThat(result.getVersion(), is(expectedVersion));
+    assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
     assertThat(
         result.getArchitectureNameVersion(),
-        equalTo(expectedArch + "-" + expectedName + "-" + expectedVersion));
-    assertThat(result.getNameVersion(), equalTo(expectedName + "-" + expectedVersion));
+        is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+    assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
   }
 
   private static String computeExpectedName(String filename) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -1,13 +1,12 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -101,16 +100,10 @@ public class PlatformDetailsTaskStaticStringTest {
   @Test
   public void testComputeLabels() throws Exception {
     PlatformDetailsTask details = new PlatformDetailsTask();
-    HashSet<String> result = details.computeLabels(arch, name, version);
-    assertThat(
-        result,
-        containsInAnyOrder(
-            expectedArch,
-            expectedName,
-            expectedVersion,
-            expectedArch + "-" + expectedName,
-            expectedName + "-" + expectedVersion,
-            expectedArch + "-" + expectedName + "-" + expectedVersion));
+    PlatformDetails result = details.computeLabels(arch, name, version);
+    assertThat(result.getArchitecture(), equalTo(expectedArch));
+    assertThat(result.getName(), equalTo(expectedName));
+    assertThat(result.getVersion(), equalTo(expectedVersion));
   }
 
   private static String computeExpectedArch(String name, String arch) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -1,7 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -101,9 +101,9 @@ public class PlatformDetailsTaskStaticStringTest {
   public void testComputeLabels() throws Exception {
     PlatformDetailsTask details = new PlatformDetailsTask();
     PlatformDetails result = details.computeLabels(arch, name, version);
-    assertThat(result.getArchitecture(), equalTo(expectedArch));
-    assertThat(result.getName(), equalTo(expectedName));
-    assertThat(result.getVersion(), equalTo(expectedVersion));
+    assertThat(result.getArchitecture(), is(expectedArch));
+    assertThat(result.getName(), is(expectedName));
+    assertThat(result.getVersion(), is(expectedVersion));
   }
 
   private static String computeExpectedArch(String name, String arch) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -1,11 +1,8 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -26,9 +23,9 @@ public class PlatformDetailsTaskTest {
   public void testCall() throws Exception {
     PlatformDetails details = platformDetailsTask.call();
     if (isWindows()) {
-      assertThat(details.getName(), equalTo("windows"));
+      assertThat(details.getName(), is("windows"));
     } else {
-      assertThat(details.getName(), not(equalTo("windows")));
+      assertThat(details.getName(), is(not("windows")));
     }
     assertPlatformDetails(details);
   }
@@ -37,23 +34,23 @@ public class PlatformDetailsTaskTest {
     String osName = System.getProperty("os.name", "os.name.is.unknown");
     if (osName.toLowerCase().startsWith("linux")) {
       String name = details.getName();
-      assertThat(name, not(equalTo("windows")));
-      assertThat(name, not(equalTo("linux")));
-      assertThat(name, not(equalTo("Linux")));
+      assertThat(name, is(not("windows")));
+      assertThat(name, is(not("linux")));
+      assertThat(name, is(not("Linux")));
       assertThat(
           name,
           anyOf(
-              equalTo("Alpine"),
-              equalTo("Amazon"),
-              equalTo("AmazonAMI"),
-              equalTo("Debian"),
-              equalTo("CentOS"),
-              equalTo("Ubuntu")));
+              is("Alpine"),
+              is("Amazon"),
+              is("AmazonAMI"),
+              is("Debian"),
+              is("CentOS"),
+              is("Ubuntu")));
       // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
       String expectedArch =
           System.getProperty("sun.arch.data.model", "23").equals("32") ? "x86" : "amd64";
       // Assumes tests run in JVM that matches operating system
-      assertThat(details.getArchitecture(), equalTo(expectedArch));
+      assertThat(details.getArchitecture(), is(expectedArch));
     }
   }
 
@@ -72,7 +69,7 @@ public class PlatformDetailsTaskTest {
     assertPlatformDetails(details);
   }
 
-  @Test()
+  @Test
   public void testComputeLabelsLinuxWithNullLsbRelease() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     LsbRelease release = null;
@@ -95,7 +92,7 @@ public class PlatformDetailsTaskTest {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     String details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy").getName();
     String name = platformDetailsTask.readReleaseIdentifier("ID");
-    assertThat(details, equalTo(name));
+    assertThat(details, is(name));
   }
 
   @Test
@@ -151,10 +148,10 @@ public class PlatformDetailsTaskTest {
       the VERSION_ID assertion.
     */
     if (version.startsWith("unknown")) {
-      assertThat(details.getName(), equalTo("Debian"));
-      assertThat(details.getVersion(), equalTo("testing"));
+      assertThat(details.getName(), is("Debian"));
+      assertThat(details.getVersion(), is("testing"));
     } else {
-      assertThat(details.getVersion(), anyOf(equalTo(version), equalTo(foundValue)));
+      assertThat(details.getVersion(), anyOf(is(version), is(foundValue)));
     }
   }
 

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -1,13 +1,15 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,41 +24,42 @@ public class PlatformDetailsTaskTest {
 
   @Test
   public void testCall() throws Exception {
-    Set<String> details = platformDetailsTask.call();
+    PlatformDetails details = platformDetailsTask.call();
     if (isWindows()) {
-      assertThat(details, hasItems("windows"));
+      assertThat(details.getName(), equalTo("windows"));
     } else {
-      assertThat(details, not(hasItems("windows")));
+      assertThat(details.getName(), not(equalTo("windows")));
     }
     assertPlatformDetails(details);
   }
 
-  private void assertPlatformDetails(Set<String> details) {
+  private void assertPlatformDetails(PlatformDetails details) {
     String osName = System.getProperty("os.name", "os.name.is.unknown");
     if (osName.toLowerCase().startsWith("linux")) {
-      assertThat(details, not(hasItems("windows")));
-      assertThat(details, not(hasItems("linux")));
-      assertThat(details, not(hasItems("Linux")));
+      String name = details.getName();
+      assertThat(name, not(equalTo("windows")));
+      assertThat(name, not(equalTo("linux")));
+      assertThat(name, not(equalTo("Linux")));
       assertThat(
-          details,
+          name,
           anyOf(
-              hasItems("Alpine"),
-              hasItems("Amazon"),
-              hasItems("AmazonAMI"),
-              hasItems("Debian"),
-              hasItems("CentOS"),
-              hasItems("Ubuntu")));
+              equalTo("Alpine"),
+              equalTo("Amazon"),
+              equalTo("AmazonAMI"),
+              equalTo("Debian"),
+              equalTo("CentOS"),
+              equalTo("Ubuntu")));
       // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
       String expectedArch =
           System.getProperty("sun.arch.data.model", "23").equals("32") ? "x86" : "amd64";
       // Assumes tests run in JVM that matches operating system
-      assertThat(details, hasItems(expectedArch));
+      assertThat(details.getArchitecture(), equalTo(expectedArch));
     }
   }
 
   @Test
   public void testComputeLabelsLinux32Bit() throws Exception {
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
     assertPlatformDetails(details);
   }
 
@@ -65,16 +68,15 @@ public class PlatformDetailsTaskTest {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     LsbRelease release = new LsbRelease(unknown, unknown);
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy", release);
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy", release);
     assertPlatformDetails(details);
   }
 
-  @Test
+  @Test()
   public void testComputeLabelsLinuxWithNullLsbRelease() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
-    String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     LsbRelease release = null;
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy", release);
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy", release);
     assertPlatformDetails(details);
   }
 
@@ -91,14 +93,14 @@ public class PlatformDetailsTaskTest {
   @Test
   public void compareOSName() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+    String details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy").getName();
     String name = platformDetailsTask.readReleaseIdentifier("ID");
-    assertThat(details, hasItems(name));
+    assertThat(details, equalTo(name));
   }
 
   @Test
   public void readReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
     platformDetailsTask.setOsReleaseFile(new File("/this/file/does/not/exist"));
     String name = platformDetailsTask.readReleaseIdentifier("ID");
     assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
@@ -106,7 +108,7 @@ public class PlatformDetailsTaskTest {
 
   @Test
   public void readRedhatReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
     platformDetailsTask.setRedhatRelease(new File("/this/file/does/not/exist"));
     String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
     assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
@@ -114,7 +116,7 @@ public class PlatformDetailsTaskTest {
 
   @Test
   public void readRedhatReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
     platformDetailsTask.setRedhatRelease(null);
     String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
     assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
@@ -122,7 +124,7 @@ public class PlatformDetailsTaskTest {
 
   @Test
   public void readRedhatReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
     platformDetailsTask.setRedhatRelease(new File("/etc/hosts")); // Not redhat-release file
     String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
     assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
@@ -131,7 +133,7 @@ public class PlatformDetailsTaskTest {
   @Test
   public void compareOSVersion() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
-    Set<String> details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
+    PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");
     String version = platformDetailsTask.readReleaseIdentifier("VERSION_ID");
     /* Check that the version string returned by readReleaseIdentifier
     is at least at the beginning of one of the detail values. Allow
@@ -139,10 +141,8 @@ public class PlatformDetailsTaskTest {
     in the /etc/os-release file without reporting their incremental
     version */
     String foundValue = version;
-    for (String detail : details) {
-      if (detail.startsWith(version)) {
-        foundValue = detail;
-      }
+    if (details.getVersion().startsWith(version)) {
+      foundValue = details.getVersion();
     }
     /* If VERSION_ID has the unknown value then handle it as a special
       case.  Debian testing does not include a VERSION_ID value in
@@ -151,9 +151,10 @@ public class PlatformDetailsTaskTest {
       the VERSION_ID assertion.
     */
     if (version.startsWith("unknown")) {
-      assertThat(details, hasItems("Debian", "testing"));
+      assertThat(details.getName(), equalTo("Debian"));
+      assertThat(details.getVersion(), equalTo("testing"));
     } else {
-      assertThat(details, anyOf(hasItems(version), hasItems(foundValue)));
+      assertThat(details.getVersion(), anyOf(equalTo(version), equalTo(foundValue)));
     }
   }
 

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
@@ -23,7 +23,7 @@
  */
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import hudson.model.labels.LabelAtom;
 import java.util.Collection;

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
@@ -23,7 +23,7 @@
  */
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import hudson.model.labels.LabelAtom;
 import java.util.Collection;
@@ -43,7 +43,7 @@ public class PlatformLabelerTest {
     expected.add(j.jenkins.getLabelAtom("foo"));
     expected.add(j.jenkins.getLabelAtom("bar"));
     NodeLabelCache.nodeLabels.put(j.jenkins, expected);
-    Collection labels = new PlatformLabeler().findLabels(j.jenkins);
+    Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
     assertEquals(expected, labels);
   }
 
@@ -53,7 +53,7 @@ public class PlatformLabelerTest {
     if (NodeLabelCache.nodeLabels.containsKey(j.jenkins)) {
       NodeLabelCache.nodeLabels.remove(j.jenkins);
     }
-    Collection labels = new PlatformLabeler().findLabels(j.jenkins);
+    Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
     assertEquals(0, labels.size());
   }
 }


### PR DESCRIPTION
In certain cases one doesn't want to have all the generated labels on certain nodes. Additionally add a global configuration for the labels.

## [JENKINS-17904](https://issues.jenkins-ci.org/browse/JENKINS-17904)- Allow to configure labels per node

Add a global configuration page and a NodeProperty to configure which labels are generated. With the NodeProperty one can overwrite the global configuration. The default behavior will not change the currently generated labels.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

This might also fix [JENKINS-17615](https://issues.jenkins-ci.org/browse/JENKINS-17615).
The problem could be that the Node object gets destroyed and recreated when a node config changes while the associated Computer is untouched when the connection itself is unchanged (e.g. just a label change).  I noticed that when changing the nodeproperty my changes didn't get reflected. Only after caching the computer it started working.