### PR TITLE
Fix checkstyle warnings from recent changes

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
@@ -7,7 +7,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-/** Stores configuration about labels to generate */
+/** Stores configuration about labels to generate. */
 public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
 
   private boolean architecture = true;

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -48,7 +48,7 @@ import jenkins.model.Jenkins;
 @Extension
 public class NodeLabelCache extends ComputerListener {
 
-  /** The OS properties for nodes * */
+  /** The OS properties for nodes. */
   private static transient Map<Computer, PlatformDetails> nodePlatformProperties =
       Collections.synchronizedMap(new WeakHashMap<>());
   /** The labels computed for nodes - accessible package wide. */
@@ -72,7 +72,7 @@ public class NodeLabelCache extends ComputerListener {
     refreshModel(computer);
   }
 
-  /** When any computer has changed, update the platform labels according to the configuration */
+  /** When any computer has changed, update the platform labels according to the configuration. */
   @Override
   public final void onConfigurationChange() {
     synchronized (nodePlatformProperties) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -2,7 +2,7 @@ package org.jvnet.hudson.plugins.platformlabeler;
 
 import java.io.Serializable;
 
-/** Stores the platform details of a node */
+/** Stores the platform details of a node. */
 public class PlatformDetails implements Serializable {
 
   private static final long serialVersionUID = 1L;
@@ -14,6 +14,13 @@ public class PlatformDetails implements Serializable {
   private final String architectureName;
   private final String nameVersion;
 
+  /**
+   * Platform details constructor.
+   *
+   * @param name name of operating system, as in windows, debian, ubuntu, etc.
+   * @param architecture hardware architecture, as in amd64, aarh64, etc.
+   * @param version version of operating system, as in 9.1, 14.04, etc.
+   */
   public PlatformDetails(String name, String architecture, String version) {
     this.name = name;
     this.architecture = architecture;

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -216,9 +216,9 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
   }
 
   /**
-   * Maps the ID string from /etc/os-release and /etc/redhat-release to the Distributor ID value
-   * output by lsb_release -a so that users have the same operating system name in the label whether
-   * the label was generated using os-release or using lsb_release
+   * Maps the ID string from /etc/os-release and /etc/redhat-release to the Distributor ID value.
+   * Matches output by lsb_release -a so that users have the same operating system name in the label
+   * whether the label was generated using os-release or using lsb_release.
    */
   private static final Map<String, String> PREFERRED_LINUX_OS_NAMES = new HashMap<>();
 

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -287,9 +287,10 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
           if (field.equals("ID")) {
             value = line.substring(0, line.indexOf(RELEASE)).trim();
           }
-          if (field.equals("VERSION_ID"))
+          if (field.equals("VERSION_ID")) {
             value =
                 line.substring(line.indexOf(RELEASE) + RELEASE.length(), line.indexOf("(")).trim();
+          }
         }
       }
     } catch (IOException notFound) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
@@ -15,6 +15,7 @@ public class PlatformLabelerGlobalConfiguration extends GlobalConfiguration {
 
   private LabelConfig labelConfig;
 
+  /** Standard constructor. */
   public PlatformLabelerGlobalConfiguration() {
     load();
     if (labelConfig == null) {


### PR DESCRIPTION
## Fix checkstyle warnings from recent changes

The checkstyle warnings are generally not useful, but it is easier to have 0 checkstyle warnings than to remember which warnings can be ignored.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Infrastructure