### PR TITLE
[JENKINS-59480] support for SUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Labels commonly include operating system name, version, and architecture.
 | Red Hat Enterprise Linux 8 | `RedHatEnterprise` | `8.0`          | `amd64`  |
 | Scientific 6.10            | `Scientific`       | `6.10`         | `amd64`  |
 | Scientific 7.7             | `Scientific`       | `7.7`          | `amd64`  |
+| SLES 11.3                  | `SUSE LINUX`       | `11.3`          | `amd64`  |
+| SLES 12.1                  | `SUSE LINUX`       | `12.1`          | `amd64`  |
+| SLES 12.2                  | `SUSE`              | `12.2`          | `amd64`  |
+| SLES 15                    | `SUSE`              | `15`          | `amd64`  |
 | Ubuntu 14                  | `Ubuntu`           | `14.04`        | `amd64`  |
 | Ubuntu 16                  | `Ubuntu`           | `16.04`        | `amd64`  |
 | Ubuntu 18                  | `Ubuntu`           | `18.04`        | `amd64`  |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Labels commonly include operating system name, version, and architecture.
 On Linux computers, the plugin uses the output of the [`lsb_release`](https://linux.die.net/man/1/lsb_release) command.
 If `lsb_release` is not installed, labels on Linux agents will be guessed based on values in /etc/os-release.
 Redhat and Scientific agents have another fallback based on /etc/redhat-release.
+Agents with an older version of SuSE will fallback to /etc/SuSE-release. Older versions of this plugin might return "sles" or "SUSE LINUX" as OS name. 
+This has been unified to "SUSE" as this is the lsb_release ID since SLES 12 SP2.
+
 When /etc/os-release is used, less detailed labels are provided.
 For example:
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Labels commonly include operating system name, version, and architecture.
 | Red Hat Enterprise Linux 8 | `RedHatEnterprise` | `8.0`          | `amd64`  |
 | Scientific 6.10            | `Scientific`       | `6.10`         | `amd64`  |
 | Scientific 7.7             | `Scientific`       | `7.7`          | `amd64`  |
-| SLES 11.3                  | `SUSE LINUX`       | `11.3`          | `amd64`  |
-| SLES 12.1                  | `SUSE LINUX`       | `12.1`          | `amd64`  |
+| SLES 11.3                  | `SUSE`              | `11.3`          | `amd64`  |
+| SLES 12.1                  | `SUSE`              | `12.1`          | `amd64`  |
 | SLES 12.2                  | `SUSE`              | `12.2`          | `amd64`  |
 | SLES 15                    | `SUSE`              | `15`          | `amd64`  |
 | Ubuntu 14                  | `Ubuntu`           | `14.04`        | `amd64`  |

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <compatibleSinceVersion>4.1</compatibleSinceVersion>
+        </configuration>
+      </plugin>       
       <!-- Fail build on pom formatting errors -->
       <!-- Fix with mvn tidy:pom -->
       <plugin>

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -216,8 +216,12 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         computedName = readSuseReleaseIdentifier("ID");
       }
       /* This is kind of a hack. lsb_release -a returns only the major version on SLES 11 and older,
-       * so trying to fall back to reading SuSE-release file to get a more detailed version */
+       * so trying to fall back to reading SuSE-release file to get a more detailed version including the SP
+       * Up to SLES 12 SP1, lsb_release returned "SUSE LINUX" as ID. As spaces in labels make label management
+       * more complex and we want to have the same label, we replace "SUSE LINUX" with "SUSE".
+       */
       if (computedName.equals("SUSE LINUX")) {
+        computedName = "SUSE";
         try {
           int intVersion = Integer.parseInt(computedVersion);
           if (intVersion <= 11) {
@@ -227,7 +231,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             }
           }
         } catch (NumberFormatException nfe) {
-          // Ignore IOException
+          // Ignore NumberFormatException
         }
       }
       if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -61,6 +61,10 @@ public class PlatformDetailsTaskLsbReleaseTest {
     File lsbReleaseFile = new File(resource.toURI());
     assertTrue("File not found " + lsbReleaseFile, lsbReleaseFile.exists());
     LsbRelease release = new LsbRelease(lsbReleaseFile);
+    File suseReleaseFile = new File(lsbReleaseFile.getParentFile(), "SuSE-release");
+    if (suseReleaseFile.isFile()) {
+      details.setSuseRelease(suseReleaseFile);
+    }
     PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
     assertThat(result.getArchitecture(), is(expectedArch));
     assertThat(result.getName(), is(expectedName));
@@ -98,6 +102,12 @@ public class PlatformDetailsTaskLsbReleaseTest {
     }
     if (filename.contains("scientific")) {
       return "Scientific";
+    }
+    if (filename.contains("sles")) {
+      if (filename.contains("sles/12.1") || filename.contains("sles/11")) {
+        return "SUSE LINUX";
+      }
+      return "SUSE";
     }
     return filename.toLowerCase();
   }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -33,7 +33,7 @@ public class PlatformDetailsTaskLsbReleaseTest {
   }
 
   /**
-   * Generate test parameters for Linux os-release sample files stored as resources.
+   * Generate test parameters for Linux lsb_release-a sample files stored as resources.
    *
    * @return parameter values to be tested
    */
@@ -104,9 +104,6 @@ public class PlatformDetailsTaskLsbReleaseTest {
       return "Scientific";
     }
     if (filename.contains("sles")) {
-      if (filename.contains("sles/12.1") || filename.contains("sles/11")) {
-        return "SUSE LINUX";
-      }
       return "SUSE";
     }
     return filename.toLowerCase();

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -33,8 +33,8 @@ public class PlatformDetailsTaskReleaseTest {
   }
 
   /**
-   * Generate test parameters for Linux os-release and redhat-release sample files stored as
-   * resources.
+   * Generate test parameters for Linux os-release, redhat-release and SuSE-release sample files
+   * stored as resources.
    *
    * @return parameter values to be tested
    */

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -64,9 +64,15 @@ public class PlatformDetailsTaskReleaseTest {
     if (releaseFile.getName().startsWith("redhat")) {
       details.setOsReleaseFile(null);
       details.setRedhatRelease(releaseFile);
+      details.setSuseRelease(null);
+    } else if (releaseFile.getName().startsWith("SuSE")) {
+      details.setOsReleaseFile(null);
+      details.setSuseRelease(releaseFile);
+      details.setRedhatRelease(null);
     } else {
       details.setOsReleaseFile(releaseFile);
       details.setRedhatRelease(null);
+      details.setSuseRelease(null);
     }
     String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     LsbRelease release = new LsbRelease(unknown, unknown);
@@ -105,6 +111,9 @@ public class PlatformDetailsTaskReleaseTest {
     }
     if (filename.contains("scientific")) {
       return "Scientific";
+    }
+    if (filename.contains("sles")) {
+      return "SUSE";
     }
     return filename.toLowerCase();
   }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -128,6 +128,28 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  public void readSuseReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
+    platformDetailsTask.setSuseRelease(new File("/this/file/does/not/exist"));
+    String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
+    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+  }
+
+  @Test
+  public void readSuseReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
+    platformDetailsTask.setSuseRelease(null);
+    String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
+    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+  }
+
+  @Test
+  public void readSuseReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
+    assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/hosts")));
+    platformDetailsTask.setSuseRelease(new File("/etc/hosts")); // Not SuSE-release file
+    String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
+    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+  }
+
+  @Test
   public void compareOSVersion() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     PlatformDetails details = platformDetailsTask.computeLabels("x86", "linux", "xyzzy");

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/11.3/SuSE-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/11.3/SuSE-release
@@ -1,0 +1,3 @@
+SUSE Linux Enterprise Server 11 (x86_64)
+VERSION = 11
+PATCHLEVEL = 3

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/11.3/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/11.3/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:    core-2.0-noarch:core-3.2-noarch:core-4.0-noarch:core-2.0-x86_64:core-3.2-x86_64:core-4.0-x86_64:desktop-4.0-amd64:desktop-4.0-noarch:graphics-2.0-amd64:graphics-2.0-noarch:graphics-3.2-amd64:graphics-3.2-noarch:graphics-4.0-amd64:graphics-4.0-noarch
+Distributor ID: SUSE LINUX
+Description:    SUSE Linux Enterprise Server 11 (x86_64)
+Release:        11
+Codename:       n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.1/SuSE-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.1/SuSE-release
@@ -1,0 +1,5 @@
+SUSE Linux Enterprise Server 12 (x86_64)
+VERSION = 12
+PATCHLEVEL = 1
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.1/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.1/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:    n/a
+Distributor ID: SUSE LINUX
+Description:    SUSE Linux Enterprise Server 12 SP1
+Release:        12.1
+Codename:       n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.1/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.1/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="12-SP1"
+VERSION_ID="12.1"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP1"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp1"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.3/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.3/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:    n/a
+Distributor ID: SUSE
+Description:    SUSE Linux Enterprise Server 12 SP3
+Release:        12.3
+Codename:       n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.3/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.3/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="12-SP3"
+VERSION_ID="12.3"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp3"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.4/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.4/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:    n/a
+Distributor ID: SUSE
+Description:    SUSE Linux Enterprise Server 12 SP4
+Release:        12.4
+Codename:       n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.4/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/12.4/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="12-SP4"
+VERSION_ID="12.4"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP4"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp4"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/15/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/15/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:    n/a
+Distributor ID: SUSE
+Description:    SUSE Linux Enterprise Server 15
+Release:        15
+Codename:       n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/15/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/15/os-release
@@ -1,0 +1,8 @@
+NAME="SLES"
+VERSION="15"
+VERSION_ID="15"
+PRETTY_NAME="SUSE Linux Enterprise Server 15"
+ID="sles"
+ID_LIKE="suse"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:15"


### PR DESCRIPTION
## [JENKINS-59480](https://issues.jenkins-ci.org/browse/JENKINS-59480) - support for SUSE

Older SUSE release (until 12) have a file /etc/SuSE-release.  /etc/os-release only exists from SLES 12 onwards. On SLES11 and earlier the lsb_release only provides the major version but not the patch level.  This change adds support for reading the SuSE-release file and falling back to it on SLES11 and older to get better vesrion information. It will also map "sles" from /etc/os-release to "SUSE LINUX"

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Further comments

Up to SLES12 SP1, lsb_release returns "SUSE LINUX" from 12.2 onwards only "SUSE" is returned. Should this be unified to always return "SUSE" or "SUSE LINUX"?

This change is breaking in the sense that before when only reading /etc/os-release, the platform name would have been "sles", now it will be "SUSE".

In case there will be more platforms that need special handling it might make sense to have an extension point for this.