### PR TITLE
Use SUSE methods in SUSE tests

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -130,14 +130,14 @@ public class PlatformDetailsTaskTest {
   @Test
   public void readSuseReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
     platformDetailsTask.setSuseRelease(new File("/this/file/does/not/exist"));
-    String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
+    String name = platformDetailsTask.readSuseReleaseIdentifier("ID");
     assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
   }
 
   @Test
   public void readSuseReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
     platformDetailsTask.setSuseRelease(null);
-    String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
+    String name = platformDetailsTask.readSuseReleaseIdentifier("ID");
     assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
   }
 
@@ -145,7 +145,7 @@ public class PlatformDetailsTaskTest {
   public void readSuseReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/hosts")));
     platformDetailsTask.setSuseRelease(new File("/etc/hosts")); // Not SuSE-release file
-    String name = platformDetailsTask.readRedhatReleaseIdentifier("ID");
+    String name = platformDetailsTask.readSuseReleaseIdentifier("ID");
     assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
   }
 


### PR DESCRIPTION
## Use SUSE methods in SUSE tests

My code review missed that the newly added SUSE tests were configuring the SUSE release file but are then calling the  Red Hat release ID reader.  Call the SUSE methods inside the SUSE tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests

### Other comments

Failures were detected when running the tests on CentOS.  SInce ci.jenkins.io runs on Debian and Windows, it did not detect the test failures.

@mawinter69 I would like to have a code review from you to confirm that I've expressed your intent correctly in these tests.