### PR TITLE
Convert several tests to use JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
     <!-- No API's intended to be used, none should be called from outside. -->
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
+    <junit.version>4.12</junit.version>
+    <junit.jupiter.version>5.5.2</junit.jupiter.version>
+    <junit.params.version>5.5.2</junit.params.version>
+    <junit.vintage.version>5.5.2</junit.vintage.version>
   </properties>
 
   <dependencyManagement>
@@ -101,6 +105,31 @@
         </exclusion>
       </exclusions>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.vintage.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.params.version}</version>
+      <type>jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -9,36 +9,20 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.reflections.Reflections;
 import org.reflections.scanners.ResourcesScanner;
 
-@RunWith(Parameterized.class)
 public class PlatformDetailsTaskLsbReleaseTest {
-
-  private final String lsbReleaseFileName;
-  private final String expectedName;
-  private final String expectedVersion;
-  private final String expectedArch;
-
-  public PlatformDetailsTaskLsbReleaseTest(
-      String lsbReleaseFileName, String expectedName, String expectedVersion, String expectedArch) {
-    this.lsbReleaseFileName = lsbReleaseFileName;
-    this.expectedName = expectedName;
-    this.expectedVersion = expectedVersion;
-    this.expectedArch = expectedArch;
-  }
 
   /**
    * Generate test parameters for Linux lsb_release-a sample files stored as resources.
    *
    * @return parameter values to be tested
    */
-  @Parameters(name = "{1}-{2}-{3}")
-  public static Collection<Object[]> generateReleaseFileNames() {
+  public static Stream<Object[]> generateReleaseFileNames() {
     String packageName = PlatformDetailsTaskLsbReleaseTest.class.getPackage().getName();
     Reflections reflections = new Reflections(packageName, new ResourcesScanner());
     Set<String> fileNames = reflections.getResources(Pattern.compile(".*lsb_release-a"));
@@ -51,11 +35,14 @@ public class PlatformDetailsTaskLsbReleaseTest {
       Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
       data.add(oneTest);
     }
-    return data;
+    return data.stream();
   }
 
-  @Test
-  public void testComputeLabelsForOsRelease() throws Exception {
+  @ParameterizedTest
+  @MethodSource("generateReleaseFileNames")
+  public void testComputeLabelsForOsRelease(
+      String lsbReleaseFileName, String expectedName, String expectedVersion, String expectedArch)
+      throws Exception {
     PlatformDetailsTask details = new PlatformDetailsTask();
     URL resource = getClass().getResource(lsbReleaseFileName);
     File lsbReleaseFile = new File(resource.toURI());

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -9,28 +9,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.reflections.Reflections;
 import org.reflections.scanners.ResourcesScanner;
 
-@RunWith(Parameterized.class)
 public class PlatformDetailsTaskReleaseTest {
-
-  private final String releaseFileName;
-  private final String expectedName;
-  private final String expectedVersion;
-  private final String expectedArch;
-
-  public PlatformDetailsTaskReleaseTest(
-      String releaseFileName, String expectedName, String expectedVersion, String expectedArch) {
-    this.releaseFileName = releaseFileName;
-    this.expectedName = expectedName;
-    this.expectedVersion = expectedVersion;
-    this.expectedArch = expectedArch;
-  }
 
   /**
    * Generate test parameters for Linux os-release, redhat-release and SuSE-release sample files
@@ -38,8 +23,7 @@ public class PlatformDetailsTaskReleaseTest {
    *
    * @return parameter values to be tested
    */
-  @Parameters(name = "{1}-{2}-{3}-{0}")
-  public static Collection<Object[]> generateReleaseFileNames() {
+  public static Stream<Object[]> generateReleaseFileNames() {
     String packageName = PlatformDetailsTaskReleaseTest.class.getPackage().getName();
     Reflections reflections = new Reflections(packageName, new ResourcesScanner());
     Set<String> fileNames = reflections.getResources(Pattern.compile(".*-release"));
@@ -52,11 +36,14 @@ public class PlatformDetailsTaskReleaseTest {
       Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
       data.add(oneTest);
     }
-    return data;
+    return data.stream();
   }
 
-  @Test
-  public void testComputeLabelsForRelease() throws Exception {
+  @ParameterizedTest
+  @MethodSource("generateReleaseFileNames")
+  public void testComputeLabelsForRelease(
+      String releaseFileName, String expectedName, String expectedVersion, String expectedArch)
+      throws Exception {
     PlatformDetailsTask details = new PlatformDetailsTask();
     URL resource = getClass().getResource(releaseFileName);
     File releaseFile = new File(resource.toURI());

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -1,14 +1,14 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PlatformDetailsTaskTest {
 
@@ -25,7 +25,7 @@ public class PlatformDetailsTaskTest {
   private static final String SPECIAL_CASE_ARCH =
       SYSTEM_OS_ARCH.contains("amd") ? "x86" : SYSTEM_OS_ARCH;
 
-  @Before
+  @BeforeEach
   public void createPlatformDetailsTask() {
     platformDetailsTask = new PlatformDetailsTask();
   }
@@ -100,7 +100,7 @@ public class PlatformDetailsTaskTest {
   @Test
   public void testCheckWindows32Bit() {
     /* Always testing this case, no SPECIAL_CASE_ARCH needed */
-    assertThat(platformDetailsTask.checkWindows32Bit("x86", "AMD64", null), is("amd64"));
+    assertThat(platformDetailsTask.checkWindows32Bit("x86", "AMD64", ""), is("amd64"));
   }
 
   @Test


### PR DESCRIPTION
## Convert most tests to JUnit 5

Use JUnit 5 framework for tests instead of JUnit 4.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Refactoring

## Further comments

No Rule support in JUnit 5, so no replacement for JenkinsRule yet.