### PR TITLE
[JENKINS-59565] Support Linux Mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Labels commonly include operating system name, version, and architecture.
 | Fedora 31                  | `Fedora`           | `31`           | `amd64`      |
 | FreeBSD 11                 | `freebsd`          | `11.1-STABLE`  | `amd64`      |
 | FreeBSD 12                 | `freebsd`          | `12.0-RELEASE` | `amd64`      |
+| Linux Mint 19.3            | `LinuxMint`        | `19.03`        | `amd64`      |
 | Oracle Linux 6             | `OracleServer`     | `6.10`         | `amd64`      |
 | Oracle Linux 7             | `OracleServer`     | `7.6`          | `amd64`      |
 | Oracle Linux 8             | `OracleServer`     | `8.0`          | `amd64`      |

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -268,6 +268,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
     PREFERRED_LINUX_OS_NAMES.put("centos", "CentOS");
     PREFERRED_LINUX_OS_NAMES.put("debian", "Debian");
     PREFERRED_LINUX_OS_NAMES.put("fedora", "Fedora");
+    PREFERRED_LINUX_OS_NAMES.put("linuxmint", "LinuxMint");
     PREFERRED_LINUX_OS_NAMES.put("ol", "OracleServer");
     PREFERRED_LINUX_OS_NAMES.put("opensuse", "openSUSE");
     PREFERRED_LINUX_OS_NAMES.put("raspbian", "Raspbian");

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -86,6 +86,9 @@ public class PlatformDetailsTaskLsbReleaseTest {
     if (filename.contains("oraclelinux")) {
       return "OracleServer";
     }
+    if (filename.contains("linuxmint")) {
+      return "LinuxMint";
+    }
     if (filename.contains("raspbian")) {
       return "Raspbian";
     }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -92,6 +92,9 @@ public class PlatformDetailsTaskReleaseTest {
     if (filename.contains("fedora")) {
       return "Fedora";
     }
+    if (filename.contains("linuxmint")) {
+      return "LinuxMint";
+    }
     if (filename.contains("oraclelinux")) {
       return "OracleServer";
     }

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/linuxmintd/19.3/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/linuxmintd/19.3/Dockerfile
@@ -1,0 +1,2 @@
+FROM linuxmintd/mint19.3-amd64:latest
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/linuxmintd/19.3/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/linuxmintd/19.3/lsb_release-a
@@ -1,0 +1,4 @@
+Distributor ID:	LinuxMint
+Description:	Linux Mint 19.3 Tricia
+Release:	19.3
+Codename:	tricia

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/linuxmintd/19.3/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/linuxmintd/19.3/os-release
@@ -1,0 +1,12 @@
+NAME="Linux Mint"
+VERSION="19.3 (Tricia)"
+ID=linuxmint
+ID_LIKE=ubuntu
+PRETTY_NAME="Linux Mint 19.3"
+VERSION_ID="19.3"
+HOME_URL="https://www.linuxmint.com/"
+SUPPORT_URL="https://forums.ubuntu.com/"
+BUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedocs.io/en/latest/"
+PRIVACY_POLICY_URL="https://www.linuxmint.com/"
+VERSION_CODENAME=tricia
+UBUNTU_CODENAME=bionic


### PR DESCRIPTION
## [JENKINS-59565](https://issues.jenkins-ci.org/browse/JENKINS-59565) Support Linux Mint

Automatically label Linux Mint agents whether they have installed lsb_release or not.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)