### PR TITLE
Reuse SUSE value instead of reading again

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -238,7 +238,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
           if (intVersion <= 11) {
             String newVersion = readSuseReleaseIdentifier("VERSION_ID");
             if (!newVersion.equals(UNKNOWN_VALUE_STRING)) {
-              computedVersion = readSuseReleaseIdentifier("VERSION_ID");
+              computedVersion = newVersion;
             }
           }
         } catch (NumberFormatException nfe) {


### PR DESCRIPTION
## Reuse SUSE value instead of reading again

Minor code improvement.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Minor improvement