### PR TITLE
Use parent pom 3.52

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.51</version>
+    <version>3.52</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,29 @@
       <type>jar</type>
       <scope>test</scope>
     </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>1.0</version>
+      </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+      <version>1.16</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>annotation-indexer</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <junit.version>4.12</junit.version>
-    <junit.jupiter.version>5.5.2</junit.jupiter.version>
-    <junit.params.version>5.5.2</junit.params.version>
-    <junit.vintage.version>5.5.2</junit.vintage.version>
+    <junit.jupiter.version>5.6.0-M1</junit.jupiter.version>
+    <junit.params.version>5.6.0-M1</junit.params.version>
+    <junit.vintage.version>5.6.0-M1</junit.vintage.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <version>3.1.12</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
## Use parent pom 3.52

Update dependencies to use parent pom 3.52.  Also updates to latest pre-release of JUnit 5.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Dependency update