### PR TITLE
Use parent pom 3.53

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Describe the big picture of your changes here to explain to the maintainers why 
 
 ## Checklist
 
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._
+_Put an `x` in the boxes that apply. Delete items that do not apply.  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._
 
 - [ ] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
 - [ ] I have referenced the Jira issue related to my changes in one or more commit messages
@@ -16,8 +16,9 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 
 ## Types of changes
 
-What types of changes does your code introduce? _Put an `x` in the boxes that apply_
+What types of changes does your code introduce? _Put an `x` in the boxes that apply, remove the rows that do not apply_.
 
+- [ ] Dependency update
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.51</version>
+    <version>3.53</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Use parent pom 3.53

Use most recent parent pom.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update