### PR TITLE
Use uppercase letters in title

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
-  <name>Jenkins platform labeler plugin</name>
+  <name>Jenkins Platform Labeler Plugin</name>
   <description>Labels agents based on their operating system (platform) version and architecture</description>
   <url>https://github.com/jenkinsci/platformlabeler-plugin</url>
   <inceptionYear>2009</inceptionYear>


### PR DESCRIPTION
Since "Jenkins" prefix is removed from plugin name (https://github.com/jenkins-infra/update-center2/blob/master/src/main/java/org/jvnet/hudson/update_center/Plugin.java#L419 ) the plugin title in plugin manager is just "platform labeler" while other plugins are using title case.

I assume Jira issue would be an overhead here, but I can create one if needed.