### PR TITLE
Use parent pom 3.55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.54</version>
+    <version>3.55</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Use parent pom 3.55

See [parent pom release 3.55](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-3.55)
* Jenkins test harness updated from 2.56 to 2.57
* Maven hpi plugin updated from 3.10 to 3.11
* Maven source plugin updated from 3.2.0 to 3.2.1

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update