### PR TITLE
Enable JUnit 5 again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
     <!-- No API's intended to be used, none should be called from outside. -->
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
+    <junit.version>4.12</junit.version>
+    <junit.jupiter.version>5.6.0-M1</junit.jupiter.version>
+    <junit.params.version>5.6.0-M1</junit.params.version>
+    <junit.vintage.version>5.6.0-M1</junit.vintage.version>
   </properties>
 
   <dependencyManagement>
@@ -102,6 +106,31 @@
         </exclusion>
       </exclusions>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.vintage.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.params.version}</version>
+      <type>jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -9,36 +9,21 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.reflections.Reflections;
 import org.reflections.scanners.ResourcesScanner;
 
-@RunWith(Parameterized.class)
 public class PlatformDetailsTaskLsbReleaseTest {
-
-  private final String lsbReleaseFileName;
-  private final String expectedName;
-  private final String expectedVersion;
-  private final String expectedArch;
-
-  public PlatformDetailsTaskLsbReleaseTest(
-      String lsbReleaseFileName, String expectedName, String expectedVersion, String expectedArch) {
-    this.lsbReleaseFileName = lsbReleaseFileName;
-    this.expectedName = expectedName;
-    this.expectedVersion = expectedVersion;
-    this.expectedArch = expectedArch;
-  }
 
   /**
    * Generate test parameters for Linux lsb_release-a sample files stored as resources.
    *
    * @return parameter values to be tested
    */
-  @Parameters(name = "{1}-{2}-{3}")
-  public static Collection<Object[]> generateReleaseFileNames() {
+  public static Stream<Object[]> generateReleaseFileNames() {
     String packageName = PlatformDetailsTaskLsbReleaseTest.class.getPackage().getName();
     Reflections reflections = new Reflections(packageName, new ResourcesScanner());
     Set<String> fileNames = reflections.getResources(Pattern.compile(".*lsb_release-a"));
@@ -51,11 +36,15 @@ public class PlatformDetailsTaskLsbReleaseTest {
       Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
       data.add(oneTest);
     }
-    return data;
+    return data.stream();
   }
 
-  @Test
-  public void testComputeLabelsForOsRelease() throws Exception {
+  @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
+  @MethodSource("generateReleaseFileNames")
+  @DisplayName("Compute os-release labels")
+  public void testComputeLabelsForOsRelease(
+      String lsbReleaseFileName, String expectedName, String expectedVersion, String expectedArch)
+      throws Exception {
     PlatformDetailsTask details = new PlatformDetailsTask();
     URL resource = getClass().getResource(lsbReleaseFileName);
     File lsbReleaseFile = new File(resource.toURI());

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -9,28 +9,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.reflections.Reflections;
 import org.reflections.scanners.ResourcesScanner;
 
-@RunWith(Parameterized.class)
 public class PlatformDetailsTaskReleaseTest {
-
-  private final String releaseFileName;
-  private final String expectedName;
-  private final String expectedVersion;
-  private final String expectedArch;
-
-  public PlatformDetailsTaskReleaseTest(
-      String releaseFileName, String expectedName, String expectedVersion, String expectedArch) {
-    this.releaseFileName = releaseFileName;
-    this.expectedName = expectedName;
-    this.expectedVersion = expectedVersion;
-    this.expectedArch = expectedArch;
-  }
 
   /**
    * Generate test parameters for Linux os-release, redhat-release and SuSE-release sample files
@@ -38,8 +24,7 @@ public class PlatformDetailsTaskReleaseTest {
    *
    * @return parameter values to be tested
    */
-  @Parameters(name = "{1}-{2}-{3}-{0}")
-  public static Collection<Object[]> generateReleaseFileNames() {
+  public static Stream<Object[]> generateReleaseFileNames() {
     String packageName = PlatformDetailsTaskReleaseTest.class.getPackage().getName();
     Reflections reflections = new Reflections(packageName, new ResourcesScanner());
     Set<String> fileNames = reflections.getResources(Pattern.compile(".*-release"));
@@ -52,11 +37,15 @@ public class PlatformDetailsTaskReleaseTest {
       Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
       data.add(oneTest);
     }
-    return data;
+    return data.stream();
   }
 
-  @Test
-  public void testComputeLabelsForRelease() throws Exception {
+  @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
+  @MethodSource("generateReleaseFileNames")
+  @DisplayName("Compute platform details from release file")
+  public void testComputeLabelsForRelease(
+      String releaseFileName, String expectedName, String expectedVersion, String expectedArch)
+      throws Exception {
     PlatformDetailsTask details = new PlatformDetailsTask();
     URL resource = getClass().getResource(releaseFileName);
     File releaseFile = new File(resource.toURI());

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -8,39 +8,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class PlatformDetailsTaskStaticStringTest {
-
-  private final String name;
-  private final String arch;
-  private final String version;
-  private final String expectedName;
-  private final String expectedArch;
-  private final String expectedVersion;
-
-  public PlatformDetailsTaskStaticStringTest(String name, String arch, String version) {
-    this.name = name;
-    this.arch = arch;
-    this.version = version;
-    this.expectedName = computeExpectedName(name);
-    this.expectedArch = computeExpectedArch(name, arch);
-    this.expectedVersion = computeVersion(version);
-  }
 
   /**
    * Generate test parameters for cases which can be tested with static string conversions. Linux
    * platform labeling can't be tested with static string conversions. Refer to other tests for
-   * Linux platform labeling tests. Expected values are computed in the test contructor.
+   * Linux platform labeling tests.
    *
    * @return parameter values to be tested
    */
-  @Parameters(name = "{0}-{1}-{2}")
-  public static Collection<Object[]> generateTestParameters() {
+  public static Stream<Object[]> generateTestParameters() {
     Collection<Object[]> data =
         Arrays.asList(
             new Object[][] {
@@ -75,7 +57,7 @@ public class PlatformDetailsTaskStaticStringTest {
     /* Don't add data for this platform if linux - linux decodes the distribution as a label */
     String myName = System.getProperty("os.name");
     if (myName.equalsIgnoreCase("linux")) {
-      return data;
+      return data.stream();
     }
 
     /* Check this platform is in the test data */
@@ -85,7 +67,7 @@ public class PlatformDetailsTaskStaticStringTest {
       if (testData[0].equals(myName)
           && testData[1].equals(myArch)
           && testData[2].equals(myVersion)) {
-        return data;
+        return data.stream();
       }
     }
 
@@ -94,11 +76,16 @@ public class PlatformDetailsTaskStaticStringTest {
     List<Object[]> augmentedData = new ArrayList<>();
     augmentedData.add(myTestData);
     augmentedData.addAll(data);
-    return augmentedData;
+    return augmentedData.stream();
   }
 
-  @Test
-  public void testComputeLabels() throws Exception {
+  @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
+  @MethodSource("generateTestParameters")
+  @DisplayName("Compute labels from static strings")
+  public void testComputeLabels(String name, String arch, String version) throws Exception {
+    String expectedName = computeExpectedName(name);
+    String expectedArch = computeExpectedArch(name, arch);
+    String expectedVersion = computeVersion(name, version);
     PlatformDetailsTask details = new PlatformDetailsTask();
     PlatformDetails result = details.computeLabels(arch, name, version);
     assertThat(result.getArchitecture(), is(expectedArch));
@@ -129,7 +116,7 @@ public class PlatformDetailsTaskStaticStringTest {
     return name.toLowerCase();
   }
 
-  private String computeVersion(String version) {
+  private String computeVersion(String name, String version) {
     if (!name.startsWith("Windows")) {
       return version;
     }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -1,8 +1,8 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -11,8 +11,9 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 public class PlatformDetailsTaskTest {
 
@@ -29,12 +30,13 @@ public class PlatformDetailsTaskTest {
   private static final String SPECIAL_CASE_ARCH =
       SYSTEM_OS_ARCH.contains("amd") ? "x86" : SYSTEM_OS_ARCH;
 
-  @Before
+  @BeforeEach
   public void createPlatformDetailsTask() {
     platformDetailsTask = new PlatformDetailsTask();
   }
 
   @Test
+  @DisplayName("test remote call for platform details")
   public void testCall() throws Exception {
     PlatformDetails details = platformDetailsTask.call();
     if (isWindows()) {
@@ -76,6 +78,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test 32 bit Linux label computation")
   public void testComputeLabelsLinux32Bit() throws Exception {
     PlatformDetails details =
         platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
@@ -83,6 +86,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test Linux32Bit stream")
   public void testLinux32BitStream() throws IOException {
     String unameOutput = "x86_64";
     InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
@@ -90,6 +94,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test Linux32Bit stream ARM")
   public void testLinux32BitStreamARM() throws IOException {
     String unameOutput = "aarch64";
     InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
@@ -98,6 +103,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test Linux32Bit stream empty")
   public void testLinux32BitStreamEmpty() throws IOException {
     String unameOutput = "";
     String expectedArch = "Expected-Arch";
@@ -106,6 +112,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test Linux label computation without lsb_release")
   public void testComputeLabelsLinuxWithoutLsbRelease() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
@@ -116,6 +123,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test Linux label computation with null lsb_release")
   public void testComputeLabelsLinuxWithNullLsbRelease() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     LsbRelease release = null;
@@ -125,18 +133,21 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test Windows 32 bit")
   public void testCheckWindows32Bit() {
     /* Always testing this case, no SPECIAL_CASE_ARCH needed */
-    assertThat(platformDetailsTask.checkWindows32Bit("x86", "AMD64", null), is("amd64"));
+    assertThat(platformDetailsTask.checkWindows32Bit("x86", "AMD64", ""), is("amd64"));
   }
 
   @Test
+  @DisplayName("test Windows 32 bit with amd64")
   public void testCheckWindows32BitAMD64SecondArgument() {
     /* Always testing this case, no SPECIAL_CASE_ARCH needed */
     assertThat(platformDetailsTask.checkWindows32Bit("x86", "x86", "AMD64"), is("amd64"));
   }
 
   @Test
+  @DisplayName("test operating system name")
   public void compareOSName() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     String computedName =
@@ -146,6 +157,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test release identifier on missing file")
   public void readReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
     PlatformDetails details =
         platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
@@ -155,6 +167,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Read Red Hat release identifier")
   public void readRedhatReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
     PlatformDetails details =
         platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
@@ -164,6 +177,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Read Red Hat release identifier null file")
   public void readRedhatReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
     PlatformDetails details =
         platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
@@ -173,6 +187,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Read Red Hat release identifier wrong file")
   public void readRedhatReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
     PlatformDetails details =
         platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
@@ -182,6 +197,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Read SUSE release identifier missing file")
   public void readSuseReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
     platformDetailsTask.setSuseRelease(new File("/this/file/does/not/exist"));
     String name = platformDetailsTask.readSuseReleaseIdentifier("ID");
@@ -189,6 +205,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Read SUSE release identifier null file")
   public void readSuseReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
     platformDetailsTask.setSuseRelease(null);
     String name = platformDetailsTask.readSuseReleaseIdentifier("ID");
@@ -196,6 +213,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Read SUSE release identifier wrong file")
   public void readSuseReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/hosts")));
     platformDetailsTask.setSuseRelease(new File("/etc/hosts")); // Not SuSE-release file
@@ -204,6 +222,7 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Compare operating system version")
   public void compareOSVersion() throws Exception {
     assumeTrue(!isWindows() && Files.exists(Paths.get("/etc/os-release")));
     PlatformDetails details =


### PR DESCRIPTION
## Enable JUnit 5 again

Prior revert seems to be associated with a ci.jenkins.io test failure.
This change is exploring if the apparent assocation persists.

This reverts commit 60449123e96c8f7d73cf30d8bed975f607408bbb.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update