### PR TITLE
[JENKINS-60574] Fix test hang in InjectedTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,9 @@
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.0-RC1</junit.jupiter.version>
+    <!-- Fix InjectedTest hang on multi-core machines and InjectedTest failures on ci.jenkins.io -->
+    <!-- Remove when parent pom 3.56 is used -->
+    <jenkins-test-harness.version>2.60</jenkins-test-harness.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Fix test hang in InjectedTest

Use Jenkins test harness 2.60 instead of Jenkins test harness 2.57 to fix InjectedTest hang on multi-core machines.

* See [JENKINS-60574](https://issues.jenkins-ci.org/browse/JENKINS-60574)
* See [JENKINS-60694](https://issues.jenkins-ci.org/browse/JENKINS-60694)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update