### PR TITLE
Disable Dependabot eval of Jenkins core and plugins

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,3 +9,10 @@ update_configs:
       - "MarkEWaite"
     default_labels:
       - "skip-changelog"
+    ignored_updates:
+      - match:
+          dependency_name: "org.jenkins-ci.main:jenkins-core"
+      - match:
+          dependency_name: "org.jenkins-ci.plugins*"
+      - match:
+          dependency_name: "io.jenkins*"


### PR DESCRIPTION
## Disable Dependabot eval of Jenkins core and plugins

It is better for users if updates of Jenkins core dependency and Jenkins plugin dependencies are considered individually and based on more detailed analysis.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update

## Further comments

A new release of Jenkins is almost always compatible with the release on which the plugin depends. A new Jenkins release should become required when there are significant changes in the Jenkins core release that are needed by the plugin.  For example, Jenkins 2.164.1 was the first long term support release to support Java 11. The decision to upgrade the plugin to require Jenkins 2.164.1 was a decision to include Java 11 support fully.

The same logic applies to Jenkins plugin releases. When the platformlabeler plugin depends on a specific plugin version, it mandates that the user must install at least that version.  When the version of the plugin dependency is incremented without a compelling reason, it limits the choice of plugin users to that plugin version or newer.