### PR TITLE
Do not evaluate slf4j dependencies in dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,3 +16,6 @@ update_configs:
           dependency_name: "org.jenkins-ci.plugins*"
       - match:
           dependency_name: "io.jenkins*"
+      - match:
+          # Required for Jenkins 2.190.1 tests
+          dependency_name: "org.slf4j*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,8 @@ use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but s
 
 // build recommended configurations
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                                                       ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.190.1' : '2.164.1', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins: use_newer_jenkins ? '2.190.1' : '2.164.1', javaLevel: '8'  ]
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.1' : '2.190.1', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins: use_newer_jenkins ? '2.204.1' : '2.190.1', javaLevel: '8'  ]
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
   </scm>
 
   <properties>
-    <revision>5.5</revision>
+    <revision>6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.176.4</jenkins.version>
+    <jenkins.version>2.190.1</jenkins.version>
     <java.level>8</java.level>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->


### PR DESCRIPTION
## Do not evaluate slf4j dependencies in dependabot

The slf4j dependencies are included only to allow tests with Jenkins 2.190.1

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply, remove the rows that do not apply_.

- [x] Dependency update