### PR TITLE
Replace deprecated asserts with current asserts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,12 @@
           <failOnViolation>true</failOnViolation>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgument>-Xlint:deprecation</compilerArgument>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -1,7 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import hudson.model.Computer;
 import hudson.model.labels.LabelAtom;
@@ -49,7 +49,7 @@ public class ConfigurationTest {
     expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
 
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertEquals(expected, labelsAfter);
+    assertThat(expected, is(labelsAfter));
   }
 
   @Test
@@ -71,7 +71,7 @@ public class ConfigurationTest {
     expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
 
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertEquals(expected, labelsAfter);
+    assertThat(expected, is(labelsAfter));
   }
 
   @Test
@@ -93,7 +93,7 @@ public class ConfigurationTest {
     expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
 
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertEquals(expected, labelsAfter);
+    assertThat(expected, is(labelsAfter));
   }
 
   @Test
@@ -126,7 +126,7 @@ public class ConfigurationTest {
     expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
 
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertEquals(expected, labelsAfter);
+    assertThat(expected, is(labelsAfter));
   }
 
   @Test
@@ -152,7 +152,7 @@ public class ConfigurationTest {
     expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
 
     Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertEquals(expected, labelsAfter);
+    assertThat(expected, is(labelsAfter));
   }
 
   @Test

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -1,7 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import hudson.model.Computer;
 import hudson.model.Node;
@@ -197,6 +197,7 @@ public class NodeLabelCacheTest {
       throw new UnsupportedOperationException("Unsupported");
     }
 
+    @Deprecated
     public void setNodeName(String name) {
       throw new UnsupportedOperationException("Unsupported");
     }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -1,7 +1,8 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.io.FileMatchers.*;
 
 import java.io.File;
 import java.net.URL;
@@ -48,7 +49,7 @@ public class PlatformDetailsTaskLsbReleaseTest {
     PlatformDetailsTask details = new PlatformDetailsTask();
     URL resource = getClass().getResource(lsbReleaseFileName);
     File lsbReleaseFile = new File(resource.toURI());
-    assertTrue("File not found " + lsbReleaseFile, lsbReleaseFile.exists());
+    assertThat(lsbReleaseFile, is(anExistingFile()));
     LsbRelease release = new LsbRelease(lsbReleaseFile);
     File suseReleaseFile = new File(lsbReleaseFile.getParentFile(), "SuSE-release");
     if (suseReleaseFile.isFile()) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -1,7 +1,8 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.io.FileMatchers.*;
 
 import java.io.File;
 import java.net.URL;
@@ -49,7 +50,7 @@ public class PlatformDetailsTaskReleaseTest {
     PlatformDetailsTask details = new PlatformDetailsTask();
     URL resource = getClass().getResource(releaseFileName);
     File releaseFile = new File(resource.toURI());
-    assertTrue("File not found " + releaseFile, releaseFile.exists());
+    assertThat(releaseFile, is(anExistingFile()));
     if (releaseFile.getName().startsWith("redhat")) {
       details.setOsReleaseFile(null);
       details.setRedhatRelease(releaseFile);

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -1,7 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -1,7 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
## Replace deprecated asserts with current asserts

Hamcrest assert methods are preferred over JUnit assert methods

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test