### PR TITLE
Require Jenkins 2.204.2 or newer

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -17,5 +17,5 @@ update_configs:
       - match:
           dependency_name: "io.jenkins*"
       - match:
-          # Required for Jenkins 2.190.1 tests
+          # Required for Jenkins 2.204.2 tests
           dependency_name: "org.slf4j*"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,9 @@ Random random = new Random()             // Randomize which Jenkins version is s
 use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
 
 // build recommended configurations
-subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                                                       ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.1' : '2.190.1', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins: use_newer_jenkins ? '2.204.1' : '2.190.1', javaLevel: '8'  ]
+subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                                                     ],
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.2' : '2.220', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.2' : '2.220', javaLevel: '8' ]
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.190.1</jenkins.version>
+    <jenkins.version>2.204.2</jenkins.version>
     <java.level>8</java.level>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
@@ -70,28 +70,28 @@
       <version>0.9.12</version>
       <scope>test</scope>
     </dependency>
-    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>1.7.28</version>
+      <version>1.7.26</version>
       <scope>test</scope>
     </dependency>
-    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.28</version>
+      <version>1.7.26</version>
       <scope>test</scope>
     </dependency>
-    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.28</version>
+      <version>1.7.26</version>
       <scope>test</scope>
     </dependency>
-    <dependency><!-- Jenkins 2.190.1 requires this newer version -->
+    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.28</version>
+      <version>1.7.26</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Require Jenkins 2.204.2 or newer

Update Jenkins required version to 2.204.2.

Test with Jenkins 2.204.2 (most recent LTS) and with Jenkins 2.220 (most recent weekly).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Dependency update