### PR TITLE
Use ACI agents instead of traditional agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,4 @@ subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null         
                         [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.2' : '2.220', javaLevel: '8' ]
                       ]
 
-buildPlugin(configurations: subsetConfiguration, failFast: false)
+buildPlugin(forceAci: true, configurations: subsetConfiguration, failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,23 @@
           <compilerArgument>-Xlint:deprecation</compilerArgument>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.1.12.2</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <failOnError>true</failOnError>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.0.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,13 @@
           <effort>Max</effort>
           <threshold>Low</threshold>
           <failOnError>true</failOnError>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.9.0</version>
+            </plugin>
+          </plugins>
         </configuration>
         <dependencies>
           <dependency>


### PR DESCRIPTION
## Use ACI agents instead of traditional agents

Testin the changes that @slide is prototyping for faster agent allocation and destruction.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update