### PR TITLE
Add label for Windows Feature Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Adds labels to Jenkins agents based on characteristics of the operating system running the agent.
 
-Labels commonly include operating system name, version, and architecture.
+Labels commonly include operating system name, version, architecture, and Windows feature update.
 
 | Platform                   | OS Name            | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
@@ -46,6 +46,10 @@ Labels commonly include operating system name, version, and architecture.
 | Ubuntu 20                  | `Ubuntu`           | `20.04`        | `amd64`      |
 | Ubuntu 21                  | `Ubuntu`           | `21.04`        | `amd64`      |
 | Windows 10                 | `windows`          | `10.0`         | `amd64`      |
+
+On Windows computers, the plugin assigns a label based on the Windows feature update.
+Feature update labels use a two digit year and a two digit month representation.
+Common values for Windows feature update are `1809`, `1903`, `2009`, and `2109`.
 
 On Linux computers, the plugin uses the output of the [`lsb_release`](https://linux.die.net/man/1/lsb_release) command.
 

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
@@ -13,6 +13,7 @@ public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
     private boolean architecture = true;
     private boolean name = true;
     private boolean version = true;
+    private boolean windowsFeatureUpdate = true;
     private boolean architectureName = true;
     private boolean nameVersion = true;
     private boolean architectureNameVersion = true;
@@ -28,6 +29,7 @@ public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
             this.architecture = srcLabelConfig.architecture;
             this.name = srcLabelConfig.name;
             this.version = srcLabelConfig.version;
+            this.windowsFeatureUpdate = srcLabelConfig.windowsFeatureUpdate;
             this.architectureName = srcLabelConfig.architectureName;
             this.nameVersion = srcLabelConfig.nameVersion;
             this.architectureNameVersion = srcLabelConfig.architectureNameVersion;
@@ -86,6 +88,15 @@ public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
     @DataBoundSetter
     public void setArchitectureNameVersion(boolean archNameVersion) {
         this.architectureNameVersion = archNameVersion;
+    }
+
+    public boolean isWindowsFeatureUpdate() {
+        return windowsFeatureUpdate;
+    }
+
+    @DataBoundSetter
+    public void setWindowsFeatureUpdate(boolean includeWindowsFeatureUpdate) {
+        this.windowsFeatureUpdate = includeWindowsFeatureUpdate;
     }
 
     @Extension

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -38,7 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** Linux standard base release class. Provides distributor ID and release. */
-public class LsbRelease {
+public class LsbRelease implements PlatformDetailsRelease {
     @NonNull private final String distributorId;
     @NonNull private final String release;
 
@@ -91,6 +91,7 @@ public class LsbRelease {
      *
      * @return Linux distributor ID for this agent
      */
+    @Override
     @NonNull
     public String distributorId() {
         return distributorId;
@@ -101,6 +102,7 @@ public class LsbRelease {
      *
      * @return Linux release for this agent
      */
+    @Override
     @NonNull
     public String release() {
         return release;

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -187,6 +187,10 @@ public class NodeLabelCache extends ComputerListener {
             result.add(jenkins.getLabelAtom(pp.getArchitectureNameVersion()));
         }
 
+        if (labelConfig.isWindowsFeatureUpdate() && pp.getWindowsFeatureUpdate() != null) {
+            result.add(jenkins.getLabelAtom(pp.getWindowsFeatureUpdate()));
+        }
+
         return result;
     }
 

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -10,24 +10,45 @@ public class PlatformDetails implements Serializable {
     private final String name;
     private final String architecture;
     private final String version;
+    private final String windowsFeatureUpdate;
     private final String architectureNameVersion;
     private final String architectureName;
     private final String nameVersion;
 
     /**
+     * Platform details constructor (deprecated).
+     *
+     * @param name name of operating system, as in windows, debian, ubuntu, etc.
+     * @param architecture hardware architecture, as in amd64, aarch64, etc.
+     * @param version version of operating system, as in 9.1, 14.04, etc.
+     */
+    @Deprecated
+    public PlatformDetails(String name, String architecture, String version) {
+        this(name, architecture, version, null);
+    }
+
+    /**
      * Platform details constructor.
      *
      * @param name name of operating system, as in windows, debian, ubuntu, etc.
-     * @param architecture hardware architecture, as in amd64, aarh64, etc.
+     * @param architecture hardware architecture, as in amd64, aarch64, etc.
      * @param version version of operating system, as in 9.1, 14.04, etc.
+     * @param windowsFeatureUpdate windows feature update version string, as in 1809, 1903, 2009,
+     *     2103, etc.
      */
-    public PlatformDetails(String name, String architecture, String version) {
+    public PlatformDetails(
+            String name, String architecture, String version, String windowsFeatureUpdate) {
         this.name = name;
         this.architecture = architecture;
         this.version = version;
         architectureNameVersion = architecture + "-" + name + "-" + version;
         architectureName = architecture + "-" + name;
         nameVersion = name + "-" + version;
+        String featureUpdate = windowsFeatureUpdate;
+        if (featureUpdate != null && featureUpdate.isEmpty()) {
+            featureUpdate = null;
+        }
+        this.windowsFeatureUpdate = featureUpdate;
     }
 
     public String getName() {
@@ -52,5 +73,9 @@ public class PlatformDetails implements Serializable {
 
     public String getNameVersion() {
         return nameVersion;
+    }
+
+    public String getWindowsFeatureUpdate() {
+        return windowsFeatureUpdate;
     }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsRelease.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2019 Mark Waite
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Platform specific release details interface. Allows platforms to provide additional information
+ * to improve the usefulness of the generated platform labels.
+ *
+ * @author Mark Waite
+ */
+public interface PlatformDetailsRelease {
+
+    /**
+     * Return platform specific release details for this agent.
+     *
+     * @return platform specific release details for this agent
+     */
+    @NonNull
+    String release();
+
+    /**
+     * Return platform specific distributor details for this agent.
+     *
+     * @return platform specific distributor details for this agent
+     */
+    @NonNull
+    String distributorId();
+}

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2019 Tobias Gruetzmacher, Mark Waite
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Windows release class. Provides Windows feature update, 1803, 1903, 2009, 2103, 2109, etc. */
+public class WindowsRelease implements PlatformDetailsRelease {
+    @NonNull private final String release;
+
+    /** Extract distributor ID and release for current platform. */
+    public WindowsRelease() {
+        Map<String, String> newProps = new HashMap<>();
+        try {
+            Process process =
+                    new ProcessBuilder(
+                                    "REG",
+                                    "QUERY",
+                                    "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion",
+                                    "/t",
+                                    "REG_SZ",
+                                    "/v",
+                                    "ReleaseId")
+                            .start();
+            readWindowsReleaseOutput(process.getInputStream(), newProps);
+        } catch (IOException ignored) {
+            // IGNORE
+        }
+        this.release =
+                newProps.getOrDefault(
+                        "ReleaseId", PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING);
+    }
+
+    /** Read file to assign distributor ID and release. Package protected for tests. */
+    WindowsRelease(File windowsReleaseFile) throws IOException {
+        Map<String, String> newProps = new HashMap<>();
+        try (FileInputStream stream = new FileInputStream(windowsReleaseFile)) {
+            readWindowsReleaseOutput(stream, newProps);
+        }
+        this.release =
+                newProps.getOrDefault(
+                        "ReleaseId", PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING);
+    }
+
+    private void readWindowsReleaseOutput(InputStream inputStream, Map<String, String> newProps)
+            throws IOException {
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            reader.lines()
+                    .filter(s -> s.contains("REG_SZ"))
+                    .map(line -> line.split("REG_SZ", 2))
+                    .forEach(parts -> newProps.put(parts[0].trim(), parts[1].trim()));
+        }
+    }
+
+    /**
+     * Return the Windows feature update for this agent or
+     * PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING.
+     *
+     * @return Windows feature update for this agent
+     */
+    @NonNull
+    @Override
+    public String release() {
+        return release;
+    }
+
+    @NonNull
+    @Override
+    public String distributorId() {
+        return "Microsoft";
+    }
+}

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
@@ -9,6 +9,9 @@
   <f:entry field="version" title="Generate label with OS version">
     <f:checkbox default="true"/>
   </f:entry>
+  <f:entry field="windowsFeatureUpdate" title="Generate label with Windows feature update (like 1809, 1903, 2009, or 2103)">
+    <f:checkbox default="true"/>
+  </f:entry>
   <f:entry field="architectureName" title="Generate label with OS architecture and name">
     <f:checkbox default="true"/>
   </f:entry>
@@ -18,4 +21,5 @@
   <f:entry field="architectureNameVersion" title="Generate label with OS architecture, name and version">
     <f:checkbox default="true"/>
   </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
@@ -21,5 +21,4 @@
   <f:entry field="architectureNameVersion" title="Generate label with OS architecture, name and version">
     <f:checkbox default="true"/>
   </f:entry>
-
 </j:jelly>

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -39,6 +39,7 @@ public class ConfigurationTest {
         labelConfig.setArchitectureNameVersion(false);
         labelConfig.setVersion(false);
         labelConfig.setNameVersion(false);
+        labelConfig.setWindowsFeatureUpdate(false);
         nodeProperty.setLabelConfig(labelConfig);
         r.jenkins.getNodeProperties().add(nodeProperty);
 
@@ -49,7 +50,7 @@ public class ConfigurationTest {
         expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-        assertThat(expected, is(labelsAfter));
+        assertThat(labelsAfter, is(expected));
     }
 
     @Test
@@ -60,6 +61,7 @@ public class ConfigurationTest {
         labelConfig.setArchitectureNameVersion(false);
         labelConfig.setName(false);
         labelConfig.setNameVersion(false);
+        labelConfig.setWindowsFeatureUpdate(false);
         nodeProperty.setLabelConfig(labelConfig);
         r.jenkins.getNodeProperties().add(nodeProperty);
 
@@ -71,7 +73,7 @@ public class ConfigurationTest {
         expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-        assertThat(expected, is(labelsAfter));
+        assertThat(labelsAfter, is(expected));
     }
 
     @Test
@@ -91,9 +93,16 @@ public class ConfigurationTest {
         expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureName()));
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
+        if (platformDetails.getWindowsFeatureUpdate() != null) {
+            /* Non-windows won't have a WindowsFeatureUpdate value.
+             * Windows that have not installed a feature update won't
+             * have a WindowsFeatureUpdate value.
+             */
+            expected.add(r.jenkins.getLabelAtom(platformDetails.getWindowsFeatureUpdate()));
+        }
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-        assertThat(expected, is(labelsAfter));
+        assertThat(labelsAfter, is(expected));
     }
 
     @Test
@@ -112,6 +121,7 @@ public class ConfigurationTest {
         PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
         LabelConfig labelConfig = new LabelConfig();
         labelConfig.setVersion(false);
+        labelConfig.setWindowsFeatureUpdate(false);
         nodeProperty.setLabelConfig(labelConfig);
         r.jenkins.getNodeProperties().add(nodeProperty);
 
@@ -126,7 +136,7 @@ public class ConfigurationTest {
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-        assertThat(expected, is(labelsAfter));
+        assertThat(labelsAfter, is(expected));
     }
 
     @Test
@@ -139,6 +149,7 @@ public class ConfigurationTest {
 
         globalLabelConfig.setVersion(false);
         globalLabelConfig.setName(false);
+        globalLabelConfig.setWindowsFeatureUpdate(false);
         globalLabelConfig.setArchitectureName(false);
         globalLabelConfig.setArchitectureNameVersion(false);
         globalLabelConfig.setNameVersion(false);
@@ -152,7 +163,7 @@ public class ConfigurationTest {
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-        assertThat(expected, is(labelsAfter));
+        assertThat(labelsAfter, is(expected));
     }
 
     @Test
@@ -167,5 +178,8 @@ public class ConfigurationTest {
                 is(globalLabelConfigAfter.isArchitecture()));
         assertThat(globalLabelConfigBefore.isName(), is(globalLabelConfigAfter.isName()));
         assertThat(globalLabelConfigBefore.isVersion(), is(globalLabelConfigAfter.isVersion()));
+        assertThat(
+                globalLabelConfigBefore.isWindowsFeatureUpdate(),
+                is(globalLabelConfigAfter.isWindowsFeatureUpdate()));
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskWindowsReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskWindowsReleaseTest.java
@@ -1,0 +1,84 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.io.FileMatchers.*;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+
+public class PlatformDetailsTaskWindowsReleaseTest {
+
+    /**
+     * Generate test parameters for Windows feature updates using sample files stored as resources.
+     *
+     * @return parameter values to be tested
+     */
+    public static Stream<Object[]> generateWindowsReleaseFileNames() {
+        String packageName = PlatformDetailsTaskWindowsReleaseTest.class.getPackage().getName();
+        Reflections reflections = new Reflections(packageName, Scanners.Resources);
+        Set<String> fileNames = reflections.getResources(Pattern.compile(".*reg-query"));
+        Collection<Object[]> data = new ArrayList<>(fileNames.size());
+        for (String fileName : fileNames) {
+            String oneExpectedName = computeExpectedName(fileName);
+            String oneExpectedVersion = computeExpectedVersion(fileName);
+            String oneExpectedArch = "amd64";
+            String trimmedName = fileName.split(".platformlabeler.")[1];
+            Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
+            data.add(oneTest);
+        }
+        return data.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateWindowsReleaseFileNames")
+    @DisplayName("Compute reg-query labels")
+    void testComputeLabelsForOsRelease(
+            String windowsReleaseFileName,
+            String expectedName,
+            String expectedVersion,
+            String expectedArch)
+            throws Exception {
+        PlatformDetailsTask details = new PlatformDetailsTask();
+        URL resource = getClass().getResource(windowsReleaseFileName);
+        File windowsReleaseFile = new File(resource.toURI());
+        assertThat(windowsReleaseFile, is(anExistingFile()));
+        WindowsRelease release = new WindowsRelease(windowsReleaseFile);
+        PlatformDetails result = details.computeLabels("amd64", "windows", "10.0", release);
+        assertThat(result.getArchitecture(), is(expectedArch));
+        assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
+        assertThat(
+                result.getArchitectureNameVersion(),
+                is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+        assertThat(result.getName(), is(expectedName));
+        assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
+        assertThat(result.getVersion(), is(expectedVersion));
+    }
+
+    private static String computeExpectedName(String filename) {
+        if (filename.contains("windows")) {
+            return "windows";
+        }
+        return filename.toLowerCase();
+    }
+
+    private static String computeExpectedVersion(String filename) {
+        File file = new File(filename);
+        File parentDir = file.getParentFile();
+        String expectedVersion = parentDir.getName();
+        if (filename.contains("windows")) {
+            expectedVersion = expectedVersion.replaceAll("[.][0-9][0-9][0-9][0-9]$", "");
+        }
+        return expectedVersion;
+    }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2019-2021 Mark Waite
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PlatformDetailsTest {
+
+    private String name;
+    private String arch;
+    private String version;
+    private String windowsFeatureUpdate;
+    private PlatformDetails details;
+
+    public PlatformDetailsTest() {}
+
+    @BeforeEach
+    void randomizeData() {
+        name = randomName();
+        arch = randomArch();
+        version = randomVersion();
+        windowsFeatureUpdate = randomWindowsFeatureUpdate();
+        details = new PlatformDetails(name, arch, version, windowsFeatureUpdate);
+    }
+
+    @Test
+    void testGetName() {
+        assertThat(details.getName(), is(name));
+    }
+
+    @Test
+    void testGetArchitecture() {
+        assertThat(details.getArchitecture(), is(arch));
+    }
+
+    @Test
+    void testGetVersion() {
+        assertThat(details.getVersion(), is(version));
+    }
+
+    @Test
+    void testGetArchitectureNameVersion() {
+        assertThat(details.getArchitectureNameVersion(), is(arch + "-" + name + "-" + version));
+    }
+
+    @Test
+    void testGetArchitectureName() {
+        assertThat(details.getArchitectureName(), is(arch + "-" + name));
+    }
+
+    @Test
+    void testGetNameVersion() {
+        assertThat(details.getNameVersion(), is(name + "-" + version));
+    }
+
+    @Test
+    void testGetWindowsFeatureUpdate() {
+        assertThat(details.getWindowsFeatureUpdate(), is(windowsFeatureUpdate));
+    }
+
+    @Test
+    void testGetWindowsFeatureUpdateNull() {
+        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, null);
+        assertThat(nullInDetails.getWindowsFeatureUpdate(), is(nullValue()));
+    }
+
+    @Test
+    void testGetWindowsFeatureUpdateEmptyString() {
+        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, "");
+        assertThat(nullInDetails.getWindowsFeatureUpdate(), is(nullValue()));
+    }
+
+    @Test
+    @Deprecated
+    void testDetailsWithoutFeatureUpdate() {
+        PlatformDetails detailsWithoutFeatureUpdate = new PlatformDetails(name, arch, version);
+        assertThat(detailsWithoutFeatureUpdate.getWindowsFeatureUpdate(), is(nullValue()));
+    }
+
+    private final Random random = new Random();
+    private final String[] names = {
+        "Windows 10",
+        "alpine",
+        "centos",
+        "debian",
+        "fedora",
+        "freebsd",
+        "macos",
+        "raspbian",
+        "ubuntu"
+    };
+    private final String[] versions = {
+        "7.7.1908",
+        "8.2.2004",
+        "9.11",
+        "10.0",
+        "11.3",
+        "12.1",
+        "12.2",
+        "14.04",
+        "16.04",
+        "18.04",
+        "20.04",
+        "33",
+        "34",
+        "35",
+    };
+    private final String[] windowsFeatureUpdates = {
+        "1703", "1709", "1803", "1809", "1903", "1909", "2003", "2009", "2103"
+    };
+
+    private String randomName() {
+        return names[random.nextInt(names.length)];
+    }
+
+    private String randomArch() {
+        return "amd64";
+    }
+
+    private String randomVersion() {
+        return versions[random.nextInt(versions.length)];
+    }
+
+    private String randomWindowsFeatureUpdate() {
+        return windowsFeatureUpdates[random.nextInt(windowsFeatureUpdates.length)];
+    }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/WindowsReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/WindowsReleaseTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2019 Mark Waite
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.io.File;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+public class WindowsReleaseTest {
+
+    private final WindowsRelease windowsRelease = new WindowsRelease();
+    private final WindowsRelease windowsReleaseFile;
+
+    public WindowsReleaseTest() throws Exception {
+        URL resource = getClass().getResource("windows/10.0.1903/reg-query");
+        File dataFile = new File(resource.toURI());
+        windowsReleaseFile = new WindowsRelease(dataFile);
+    }
+
+    @Test
+    void testReleaseFile() {
+        assertThat(windowsReleaseFile.release(), is("1903"));
+    }
+
+    @Test
+    void testReleaseNotWindows() {
+        if (!isWindows()) {
+            assertThat(
+                    windowsRelease.release(), is(PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING));
+        }
+    }
+
+    @Test
+    void testRelease() {
+        if (isWindows()) {
+            assertThat(windowsRelease.release(), matchesPattern("[12][0-9][0-9][0-9]"));
+        }
+    }
+
+    @Test
+    void testDistributorId() {
+        assertThat(windowsRelease.distributorId(), is("Microsoft"));
+        assertThat(windowsReleaseFile.distributorId(), is("Microsoft"));
+    }
+
+    private static boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
+}

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1703/reg-query
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1703/reg-query
@@ -1,0 +1,5 @@
+
+HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion
+    ReleaseId    REG_SZ    1703
+
+End of search: 1 match(es) found.

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1709/reg-query
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1709/reg-query
@@ -1,0 +1,5 @@
+
+HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion
+    ReleaseId    REG_SZ    1709
+
+End of search: 1 match(es) found.

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1803/reg-query
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1803/reg-query
@@ -1,0 +1,5 @@
+
+HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion
+    ReleaseId    REG_SZ    1803
+
+End of search: 1 match(es) found.

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1809/reg-query
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1809/reg-query
@@ -1,0 +1,5 @@
+
+HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion
+    ReleaseId    REG_SZ    1809
+
+End of search: 1 match(es) found.

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1903/reg-query
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/windows/10.0.1903/reg-query
@@ -1,0 +1,5 @@
+
+HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion
+    ReleaseId    REG_SZ    1903
+
+End of search: 1 match(es) found.


### PR DESCRIPTION
## Add label for Windows Feature Update

Provides a new label that includes the text of the Windows Feature Update if one is installed.  Windows Feature Update versions use a two digit year followed by a two digit month of the year.  Common values for Windows Feature Update include `1703`, `1809`, `1903`, `2009`, and `2109`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update