### PR TITLE
Use bom 2.190.x, not 2.176.x

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,2 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
--Dfindbugs.skip

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <concurrency>2C</concurrency>
+    <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
 
   <dependencyManagement>
@@ -67,30 +68,6 @@
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
       <version>0.9.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
-      <version>1.7.26</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.26</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.26</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency><!-- Jenkins 2.204.2 requires this newer version -->
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.26</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.176.x</artifactId>
-        <version>5</version>
+        <artifactId>bom-2.190.x</artifactId>
+        <version>7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,16 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion><!-- Hamcrest 2.x bundles all hamcrest-core functionality in the hamcrest artifact -->
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>2.2</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <name>Jenkins Platform Labeler Plugin</name>
   <description>Labels agents based on their operating system (platform) version and architecture</description>
-  <url>https://github.com/jenkinsci/platformlabeler-plugin/blob/master/README.md</url>
+  <url>https://github.com/jenkinsci/platformlabeler-plugin/</url>
   <inceptionYear>2009</inceptionYear>
 
   <developers>


### PR DESCRIPTION
## Use bom 2.190.x, not 2.176.x

Simplify version management in the pom by using the most recent bom, 2.190.x.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update