### PR TITLE
Use hamcrest assertions, not assertEquals

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
@@ -23,7 +23,8 @@
  */
 package org.jvnet.hudson.plugins.platformlabeler;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 
 import hudson.model.labels.LabelAtom;
 import java.util.Collection;
@@ -44,7 +45,7 @@ public class PlatformLabelerTest {
     expected.add(j.jenkins.getLabelAtom("bar"));
     NodeLabelCache.nodeLabels.put(j.jenkins, expected);
     Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
-    assertEquals(expected, labels);
+    assertThat(labels, is(expected));
   }
 
   @Test
@@ -54,6 +55,6 @@ public class PlatformLabelerTest {
       NodeLabelCache.nodeLabels.remove(j.jenkins);
     }
     Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
-    assertEquals(0, labels.size());
+    assertThat(labels, is(empty()));
   }
 }


### PR DESCRIPTION
## Use hamcrest assertions, not assertEquals

JUnit assertEquals and fail have been deprecated in JUnit 4.13.  Switch to
a more recent assertion.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update

