### PR TITLE
[JENKINS-61597] Use freebsd-version for jail version number

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -248,6 +248,8 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
       if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
         computedVersion = readSuseReleaseIdentifier("VERSION_ID");
       }
+    } else if (computedName.startsWith("freebsd")) {
+      computedVersion = readFreeBSDVersion(computedVersion);
     } else if (computedName.startsWith("mac")) {
       computedName = "mac";
     }
@@ -391,5 +393,23 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
       }
     }
     return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
+  }
+
+  @NonNull
+  String readFreeBSDVersion(String version) {
+    try {
+      Process p = Runtime.getRuntime().exec("/bin/freebsd-version -u");
+      p.waitFor();
+      try (BufferedReader b =
+          new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
+        String line = b.readLine();
+        if (line != null) {
+          version = line;
+        }
+      }
+    } catch (IOException | InterruptedException e) {
+      /* Return version instead of throwing an exception */
+    }
+    return version;
   }
 }


### PR DESCRIPTION
## JENKINS-61597 Use freebsd-version for jail version number

Using the uname output on FreeBSD provides the kernel version.  The userland version is much more relevant, especially in FreeBSD jails.  This changes the behavior to label the agent with the userland version rather than the kernel version.

This change makes FreeBSD jail behaviors closer to the behavior of Docker images.  When a Docker image reports its operating system, it reads the userland values, not the kernel values.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)