### PR TITLE
Use pom 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>4.0</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <slf4jVersion>1.7.26</slf4jVersion>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <dependencyManagement>
@@ -72,7 +74,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.0.1</version>
+      <version>4.0.2</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -191,8 +193,6 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.0.0</version>
         <configuration>
-          <effort>Max</effort>
-          <threshold>Low</threshold>
           <failOnError>true</failOnError>
           <plugins>
             <plugin>
@@ -206,7 +206,7 @@
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.2</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
-    <concurrency>2C</concurrency>
     <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
       <artifactId>spotbugs-annotations</artifactId>
       <version>4.0.2</version>
       <exclusions>
-        <exclusion>
+        <exclusion><!-- prevent transitive inclusion of jsr305 -->
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <slf4jVersion>1.7.26</slf4jVersion>
     <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
@@ -193,7 +194,6 @@
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.0.0</version>
         <configuration>
-          <failOnError>true</failOnError>
           <plugins>
             <plugin>
               <groupId>com.h3xstream.findsecbugs</groupId>

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -51,6 +51,9 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
   /** Unknown field value string. Package protected for us by LsbRelease class */
   static final String UNKNOWN_VALUE_STRING = "unknown+check_lsb_release_installed";
 
+  // Added Apr 16, 2020 to resolve spotbugs warning
+  private static final long serialVersionUID = 2020 - 04 - 16;
+
   /**
    * Checks that required SLAVE role is allowed.
    *

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -36,6 +36,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -154,7 +155,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
       @NonNull final String arch, @NonNull final String name, @NonNull final String version)
       throws IOException {
     LsbRelease release;
-    if (name.toLowerCase().startsWith("linux")) {
+    if (name.toLowerCase(Locale.ENGLISH).startsWith("linux")) {
       release = new LsbRelease();
     } else {
       release = null;
@@ -180,7 +181,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
       @NonNull final String version,
       @CheckForNull LsbRelease release)
       throws IOException {
-    String computedName = name.toLowerCase();
+    String computedName = name.toLowerCase(Locale.ENGLISH);
     String computedArch = arch;
     String computedVersion = version;
     if (computedName.startsWith("windows")) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -105,7 +106,7 @@ public class PlatformDetailsTaskLsbReleaseTest {
     if (filename.contains("sles")) {
       return "SUSE";
     }
-    return filename.toLowerCase();
+    return filename.toLowerCase(Locale.ENGLISH);
   }
 
   private static String computeExpectedVersion(String filename) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -117,7 +118,7 @@ public class PlatformDetailsTaskReleaseTest {
     if (filename.contains("sles")) {
       return "SUSE";
     }
-    return filename.toLowerCase();
+    return filename.toLowerCase(Locale.ENGLISH);
   }
 
   private static String computeExpectedVersion(String filename) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -116,7 +117,7 @@ public class PlatformDetailsTaskStaticStringTest {
     if (name.startsWith("Mac")) {
       return "mac";
     }
-    return name.toLowerCase();
+    return name.toLowerCase(Locale.ENGLISH);
   }
 
   private String computeVersion(String name, String version) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Locale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class PlatformDetailsTaskTest {
   private void assertPlatformDetails(PlatformDetails details) {
     String osName = SYSTEM_OS_NAME;
     assertThat(osName, is(not(PlatformDetailsTask.UNKNOWN_VALUE_STRING)));
-    if (osName.toLowerCase().startsWith("linux")) {
+    if (osName.toLowerCase(Locale.ENGLISH).startsWith("linux")) {
       String name = details.getName();
       assertThat(name, is(not("windows")));
       assertThat(name, is(not("linux")));


### PR DESCRIPTION
## Use pom 4.0

Use Jenkins plugin pom 4.0 to reduce developer overhead and improve bug detection with static analysis.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update