### PR TITLE
Add s390x, ppc64le, and ARM64 as CI test platforms

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,17 @@ use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but s
 
 // build recommended configurations
 subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                                                     ],
-                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.2' : '2.220', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.2' : '2.220', javaLevel: '8' ]
+
+                        // Intel Linux is mislabeled as 'linux' for legacy reasons
+                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.2' : '2.222.3', javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.2' : '2.222.3', javaLevel: '8' ],
+
+                        // ARM label is Linux also
+                        [ jdk: '8' , platform: 'arm64',   jenkins: !use_newer_jenkins ? '2.204.2' : '2.234', javaLevel: '8' ],
+
+                        // PowerPC 64 and s390x labels are also Linux
+                        [ jdk: '8' , platform: 'ppc64le', jenkins: !use_newer_jenkins ? '2.222.3' : '2.234', javaLevel: '8' ],
+                        [ jdk: '11', platform: 's390x',   jenkins:  use_newer_jenkins ? '2.222.3' : '2.234', javaLevel: '8' ]
                       ]
 
 buildPlugin(forceAci: true, configurations: subsetConfiguration, failFast: false)


### PR DESCRIPTION
## Add s390x, ppc64le, and ARM64 as CI test platforms

Test on IIBM s390x, IBM PowerPC 64, and ARM 64 in CI.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update