### PR TITLE
Do not force ACI agents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,4 +18,4 @@ subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null         
                         [ jdk: '11', platform: 's390x',   jenkins:  use_newer_jenkins ? '2.222.3' : '2.234', javaLevel: '8' ]
                       ]
 
-buildPlugin(forceAci: true, configurations: subsetConfiguration, failFast: false)
+buildPlugin(configurations: subsetConfiguration, failFast: false)


### PR DESCRIPTION
## ACI agents are not available for arm64, s390x, or ppc64le

Don't use ACI agents, need real machines for arm64, s390x, and ppc64le.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
