### PR TITLE
Test more Jenkins versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,21 +1,24 @@
 #!groovy
 
-Random random = new Random()             // Randomize which Jenkins version is selected for more testing
-use_newer_jenkins = random.nextBoolean() // Use newer Jenkins on one build but slightly older on other
+import java.util.Collections
+
+// Valid Jenkins versions for test
+def testJenkinsVersions = [ '2.204.2', '2.204.6', '2.222.1', '2.222.4', '2.235', '2.239', '2.240' ]
+Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations
-subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: null                                                     ],
+subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: testJenkinsVersions[0], javaLevel: '8' ],
 
-                        // Intel Linux is mislabeled as 'linux' for legacy reasons
-                        [ jdk: '8',  platform: 'linux',   jenkins: !use_newer_jenkins ? '2.204.2' : '2.222.3', javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins:  use_newer_jenkins ? '2.204.2' : '2.222.3', javaLevel: '8' ],
+                        // Intel Linux is labeled as 'linux' for legacy reasons
+                        [ jdk: '8',  platform: 'linux',   jenkins: testJenkinsVersions[1], javaLevel: '8' ],
+                        [ jdk: '11', platform: 'linux',   jenkins: testJenkinsVersions[2], javaLevel: '8' ],
 
                         // ARM label is Linux also
-                        [ jdk: '8' , platform: 'arm64',   jenkins: !use_newer_jenkins ? '2.204.2' : '2.234', javaLevel: '8' ],
+                        [ jdk: '8',  platform: 'arm64',   jenkins: testJenkinsVersions[3], javaLevel: '8' ],
 
                         // PowerPC 64 and s390x labels are also Linux
-                        [ jdk: '8' , platform: 'ppc64le', jenkins: !use_newer_jenkins ? '2.222.3' : '2.234', javaLevel: '8' ],
-                        [ jdk: '11', platform: 's390x',   jenkins:  use_newer_jenkins ? '2.222.3' : '2.234', javaLevel: '8' ]
+                        [ jdk: '8',  platform: 'ppc64le', jenkins: testJenkinsVersions[4], javaLevel: '8' ],
+                        [ jdk: '11', platform: 's390x',   jenkins: testJenkinsVersions[5], javaLevel: '8' ],
                       ]
 
 buildPlugin(configurations: subsetConfiguration, failFast: false)


### PR DESCRIPTION
## Test more Jenkins versions

Use the additional hardware available on ci.jenkins.io to test more Jenkins versions.  Runs tests on AMD64, ARM64, PPC64, and s390x.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update