### PR TITLE
Dependabot moved inside GitHub - remove badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/platformlabeler.svg?color=blue)](https://plugins.jenkins.io/platformlabeler)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=MarkEWaite_platformlabeler-plugin&metric=alert_status)](https://sonarcloud.io/dashboard?id=MarkEWaite_platformlabeler-plugin)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3537/badge)](https://bestpractices.coreinfrastructure.org/projects/3537)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=jenkinsci/platformlabeler-plugin)](https://dependabot.com)
-<!-- [![Contributors](https://img.shields.io/github/contributors/jenkinsci/platformlabeler-plugin.svg)](https://github.com/jenkinsci/platformlabeler-plugin/graphs/contributors) -->
 
 Adds labels to Jenkins agents based on characteristics of the operating system running the agent.
 Labels commonly include operating system name, version, and architecture.


### PR DESCRIPTION
## Remove dependabot badge from README

Moved inside GitHub, badge was monitoring external dependabot.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
