### PR TITLE
Require Jenkins 2.235.1 as minimum Jenkins version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.235.1', '2.235.2', '2.235.3', '2.247', '2.248', '2.249', '2.251' ]
+def testJenkinsVersions = [ '2.235.1', '2.235.2', '2.235.3', '2.247', '2.248', '2.249', '2.250', '2.251' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.204.2', '2.204.6', '2.222.1', '2.222.4', '2.235', '2.239', '2.240' ]
+def testJenkinsVersions = [ '2.235.1', '2.235.2', '2.235.3', '2.247', '2.248', '2.249', '2.251' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <!-- No API's intended to be used, none should be called from outside. -->
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
-    <junit.jupiter.version>5.6.2</junit.jupiter.version>
+    <junit.jupiter.version>5.7.0-M1</junit.jupiter.version>
     <slf4jVersion>1.7.26</slf4jVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   </scm>
 
   <properties>
-    <revision>6.2</revision>
+    <revision>7.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.204.2</jenkins.version>
+    <jenkins.version>2.235.1</jenkins.version>
     <java.level>8</java.level>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
@@ -57,7 +57,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.204.x</artifactId>
+        <artifactId>bom-2.235.x</artifactId>
         <version>11</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.235.1 as minimum Jenkins version

Require newer Jenkins 2.235.1 since over 90% of the installations of the current release are running on Jenkins 2.235.1 or newer.  The distribution of other versions cover a very wide range.  Those who choose to upgrade are usually also upgrading their Jenkins version.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update