### PR TITLE
Test two more paths through checkWindows32Bit

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -137,6 +137,20 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("test Windows 32 bit empty second and third arguments")
+  public void testCheckWindows32BitEmptyArgs() {
+    /* Always testing this case, no SPECIAL_CASE_ARCH needed */
+    assertThat(platformDetailsTask.checkWindows32Bit("x86", "", ""), is("x86"));
+  }
+
+  @Test
+  @DisplayName("test Windows 32 bit arbitrary arch")
+  public void testCheckWindows32BitArbitraryArch() {
+    /* Always testing this case, no SPECIAL_CASE_ARCH needed */
+    assertThat(platformDetailsTask.checkWindows32Bit("not-x86", "", ""), is("not-x86"));
+  }
+
+  @Test
   @DisplayName("test Windows 32 bit")
   public void testCheckWindows32Bit() {
     /* Always testing this case, no SPECIAL_CASE_ARCH needed */


### PR DESCRIPTION
## Test two more paths through checkWindows32Bit

The paths are tested otherwise when run on Linux, but not tested on Windows.  This tests on all platforms.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test