### PR TITLE
[JENKINS-64324] Truncate version label at first slash

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -238,6 +238,13 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
       if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
         computedVersion = getRedhatReleaseIdentifier("VERSION_ID");
       }
+      /* JENKINS-64324 notes that labels with '/' break various Jenkins components */
+      /* For example, Debian testing reports its version as "testing/unstable" */
+      /* Take the portion of the version string that precedes the '/' character */
+      if (computedVersion.contains("/")) {
+        int slashLocation = computedVersion.indexOf("/");
+        computedVersion = computedVersion.substring(0, slashLocation);
+      }
       if (computedName.equals(UNKNOWN_VALUE_STRING)) {
         computedName = getSuseReleaseIdentifier("ID");
       }


### PR DESCRIPTION
## [JENKINS-64324](https://issues.jenkins.io/browse/JENKINS-64324) - Fix Debian testing label to not include '/'

The Debian testing distribution seems to have changed its `lsb_release` output to now report the release as "testing/unstable" rather than "testing" as was reported previously.  That exposes a bug in Jenkins that it is not always well behaved with agent labels that include the '/' character.

This pull request truncates the automatically generated label at the first '/' character.  The automatic label assigned to Debian testing will be `testing` even though the output of `lsb_release -r` looks like this:

```
$  lsb_release -r
Release:        testing/unstable
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
