### PR TITLE
Better tests for Debian unstable & testing

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -70,6 +70,12 @@ public class PlatformDetailsTaskReleaseTest {
     PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
     assertThat(result.getName(), is(expectedName));
     assertThat(result.getArchitecture(), is(expectedArch));
+    if (releaseFileName.matches("debian.(testing|unstable).os-release")) {
+      /* Debian testing and Debian unstable do not include a version in /etc/os-release.
+       * Expected version string is the unknown string because the value truly is unknown.
+       */
+      expectedVersion = unknown;
+    }
     assertThat(result.getVersion(), is(expectedVersion));
     assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
     assertThat(

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -191,6 +191,22 @@ public class PlatformDetailsTaskTest {
   }
 
   @Test
+  @DisplayName("Read Debian version identifier missing file")
+  void getDebianVersionIdentifierMissingFileReturnsUnknownValue() throws Exception {
+    platformDetailsTask.setDebianVersion(new File("/this/file/does/not/exist"));
+    String version = platformDetailsTask.getDebianVersionIdentifier();
+    assertThat(version, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+  }
+
+  @Test
+  @DisplayName("Read Debian version identifier null file")
+  void getDebianVersionNullFileReturnsUnknownValue() throws Exception {
+    platformDetailsTask.setDebianVersion(null);
+    String version = platformDetailsTask.getDebianVersionIdentifier();
+    assertThat(version, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+  }
+
+  @Test
   @DisplayName("Read Red Hat release identifier")
   void getRedhatReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
     PlatformDetails details =

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -66,6 +66,7 @@ public class PlatformDetailsTaskTest {
               is("Debian"),
               is("openSUSE"),
               is("Raspbian"),
+              is("SUSE"),
               is("Ubuntu")));
       // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
       String expectedArch = SYSTEM_OS_ARCH;

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:testing
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
@@ -1,0 +1,5 @@
+No LSB modules are available.
+Distributor ID:	Debian
+Description:	Debian GNU/Linux bullseye/sid
+Release:	testing
+Codename:	bullseye

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
@@ -1,0 +1,6 @@
+PRETTY_NAME="Debian GNU/Linux bullseye/sid"
+NAME="Debian GNU/Linux"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:unstable
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
@@ -1,0 +1,5 @@
+No LSB modules are available.
+Distributor ID:	Debian
+Description:	Debian GNU/Linux bullseye/sid
+Release:	unstable
+Codename:	sid

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
@@ -1,0 +1,6 @@
+PRETTY_NAME="Debian GNU/Linux bullseye/sid"
+NAME="Debian GNU/Linux"
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
## Better tests

- Add Debian unstable and testing test data
- Add Debian version for unstable and testing
- Support SUSE in test

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
