### PR TITLE
Use a debian_version file to check unstable and testing

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -238,7 +238,8 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
       if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
         computedVersion = getRedhatReleaseIdentifier("VERSION_ID");
       }
-      if (computedName.equals("debian") && computedVersion.equals(UNKNOWN_VALUE_STRING)) {
+      if (equalsIgnoreCase(computedName, "debian")
+          && computedVersion.equals(UNKNOWN_VALUE_STRING)) {
         /* Debian unstable and Debian testing don't include version in os-release */
         /* Try reading it from a different location */
         computedVersion = getDebianVersionIdentifier();

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -54,12 +54,21 @@ public class PlatformDetailsTaskReleaseTest {
     assertThat(releaseFile, is(anExistingFile()));
     if (releaseFile.getName().startsWith("redhat")) {
       details.setOsReleaseFile(null);
+      details.setDebianVersion(null);
       details.setRedhatRelease(releaseFile);
       details.setSuseRelease(null);
     } else if (releaseFile.getName().startsWith("SuSE")) {
       details.setOsReleaseFile(null);
+      details.setDebianVersion(null);
       details.setSuseRelease(releaseFile);
       details.setRedhatRelease(null);
+    } else if (releaseFile.getName().startsWith("debian")) {
+      details.setOsReleaseFile(releaseFile);
+      details.setSuseRelease(null);
+      details.setRedhatRelease(null);
+      /* Needed for Debian testing and unstable since they do not provide a version in os-release */
+      File debianVersionFile = new File(releaseFile.getParentFile(), "debian_version");
+      details.setDebianVersion(debianVersionFile.exists() ? debianVersionFile : null);
     } else {
       details.setOsReleaseFile(releaseFile);
       details.setRedhatRelease(null);
@@ -70,12 +79,6 @@ public class PlatformDetailsTaskReleaseTest {
     PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
     assertThat(result.getName(), is(expectedName));
     assertThat(result.getArchitecture(), is(expectedArch));
-    if (releaseFileName.matches("debian.(testing|unstable).os-release")) {
-      /* Debian testing and Debian unstable do not include a version in /etc/os-release.
-       * Expected version string is the unknown string because the value truly is unknown.
-       */
-      expectedVersion = unknown;
-    }
     assertThat(result.getVersion(), is(expectedVersion));
     assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
     assertThat(
@@ -133,6 +136,11 @@ public class PlatformDetailsTaskReleaseTest {
   private static String computeExpectedVersion(String filename) {
     File file = new File(filename);
     File parentDir = file.getParentFile();
+    if (parentDir.getName().equals("testing") || parentDir.getName().equals("unstable")) {
+      /* Debian unstable and Debian testing are indistinguishable by package definition */
+      /* See https://unix.stackexchange.com/questions/464812/ for more details */
+      return "bullseye";
+    }
     return parentDir.getName();
   }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -53,20 +53,23 @@ public class PlatformDetailsTaskReleaseTest {
     File releaseFile = new File(resource.toURI());
     assertThat(releaseFile, is(anExistingFile()));
     if (releaseFile.getName().startsWith("redhat")) {
+      /* Replaces os-release with Red Hat additional file */
       details.setOsReleaseFile(null);
       details.setDebianVersion(null);
       details.setRedhatRelease(releaseFile);
       details.setSuseRelease(null);
     } else if (releaseFile.getName().startsWith("SuSE")) {
+      /* Replaces os-release with SuSE additional file */
       details.setOsReleaseFile(null);
       details.setDebianVersion(null);
       details.setSuseRelease(releaseFile);
       details.setRedhatRelease(null);
-    } else if (releaseFile.getName().startsWith("debian")) {
+    } else if (releaseFileName.startsWith("debian")) {
+      /* Adds another file to consider in addition to os-release */
       details.setOsReleaseFile(releaseFile);
       details.setSuseRelease(null);
       details.setRedhatRelease(null);
-      /* Needed for Debian testing and unstable since they do not provide a version in os-release */
+      /* Extra file needed for Debian testing and unstable. No version in os-release */
       File debianVersionFile = new File(releaseFile.getParentFile(), "debian_version");
       details.setDebianVersion(debianVersionFile.exists() ? debianVersionFile : null);
     } else {

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/debian_version
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/debian_version
@@ -1,0 +1,1 @@
+bullseye/sid

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/debian_version
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/debian_version
@@ -1,0 +1,1 @@
+bullseye/sid


### PR DESCRIPTION
## Use debian_version file in tests

Provides a more precise Debian version estimate for those cases where lsb_release is not installed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
