### PR TITLE
Include Debian unstable and testing in os-release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ For example:
 | Platform                   | Operating System   | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
 | CentOS 7                   | `CentOS`           | `7`            | `amd64`      |
+| Debian testing             | `Debian`           | `bullseye`     | `amd64`      |
+| Debian unstable            | `Debian`           | `bullseye`     | `amd64`      |
 
 The types of labels can be configured globally and per agent with the 'Automatic Platform Labels' setting.
 


### PR DESCRIPTION
## Better Debian labeling when lsb_release not installed

When Debian is installed without the lsb-core package, the lsb_release command is not available. When the lsb_release command is not available, the automatic labeling uses /etc/os-release and /etc/debian_version instead.  The contents of /etc/debian_version are different than the values reported by `lsb_release -r`.  Document those differences.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation
