### PR TITLE
Allow tests to pass on Oracle Linux

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -65,6 +65,7 @@ public class PlatformDetailsTaskTest {
               is("CentOS"),
               is("Debian"),
               is("openSUSE"),
+              is("OracleServer"),
               is("Raspbian"),
               is("SUSE"),
               is("Ubuntu")));


### PR DESCRIPTION
## Add Oracle Linux to test (allow it to pass)

Oracle Linux has its own name for the OS release.  That name needs to be included in the test suite.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
