### PR TITLE
Format with git code format maven plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Please don't introduce new spotbugs output.
 
 ## Code Formatting
 
-Code formatting in the Platform Labeler plugin is maintained by fmt.
+Code formatting in the Platform Labeler plugin is maintained by the git code format maven plugin.
 The pom file format is maintained by the tidy plugin.
 Before submitting a pull request, confirm the formatting is correct with:
 
@@ -29,7 +29,7 @@ Before submitting a pull request, confirm the formatting is correct with:
 
 If the formatting is not correct, the build will fail.  Correct the formatting with:
 
-* `mvn tidy:pom fmt:format`
+* `mvn tidy:pom git-code-format:format-code -Dgcf.globPattern=**/*`
 
 ## Pre-commit Hooks
 
@@ -40,6 +40,13 @@ To install the pre-commit framework into this repository on your computer, use t
 
 ```
 $ pip install --user pre-commit
+$ pre-commit install
+```
+
+To upgrade the pre-commit framework into this repository on your computer, use the commands:
+
+```
+$ pip install --user --upgrade pre-commit
 $ pre-commit install
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,20 +159,33 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Fail build on Java formatting errors -->
-      <!-- Fix with mvn fmt:format -->
+      <!-- git code format maven plugin -->
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.9</version>
-        <executions>
-          <execution>
-            <phase>process-sources</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
+	<groupId>com.cosium.code</groupId>
+	<artifactId>git-code-format-maven-plugin</artifactId>
+	<version>2.7</version>
+	<executions>
+	  <!-- On commit, format the modified java files -->
+	  <execution>
+	    <id>install-formatter-hook</id>
+	    <goals>
+	      <goal>install-hooks</goal>
+	    </goals>
+	  </execution>
+	  <!-- On Maven verify phase, fail if any file
+	  (including unmodified) is badly formatted -->
+	  <execution>
+	    <id>validate-code-format</id>
+	    <goals>
+	      <goal>validate-code-format</goal>
+	    </goals>
+	  </execution>
+	</executions>
+	<configuration>
+	  <googleJavaFormatOptions>
+	    <aosp>true</aosp>
+	  </googleJavaFormatOptions>
+	</configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
@@ -10,75 +10,75 @@ import org.kohsuke.stapler.DataBoundSetter;
 /** Stores configuration about labels to generate. */
 public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
 
-  private boolean architecture = true;
-  private boolean name = true;
-  private boolean version = true;
-  private boolean architectureName = true;
-  private boolean nameVersion = true;
-  private boolean architectureNameVersion = true;
+    private boolean architecture = true;
+    private boolean name = true;
+    private boolean version = true;
+    private boolean architectureName = true;
+    private boolean nameVersion = true;
+    private boolean architectureNameVersion = true;
 
-  @DataBoundConstructor
-  public LabelConfig() {
-    /* Intentionally empty constructor */
-  }
+    @DataBoundConstructor
+    public LabelConfig() {
+        /* Intentionally empty constructor */
+    }
 
-  public boolean isArchitecture() {
-    return architecture;
-  }
+    public boolean isArchitecture() {
+        return architecture;
+    }
 
-  @DataBoundSetter
-  public void setArchitecture(boolean arch) {
-    this.architecture = arch;
-  }
+    @DataBoundSetter
+    public void setArchitecture(boolean arch) {
+        this.architecture = arch;
+    }
 
-  public boolean isName() {
-    return name;
-  }
+    public boolean isName() {
+        return name;
+    }
 
-  @DataBoundSetter
-  public void setName(boolean name) {
-    this.name = name;
-  }
+    @DataBoundSetter
+    public void setName(boolean name) {
+        this.name = name;
+    }
 
-  public boolean isVersion() {
-    return version;
-  }
+    public boolean isVersion() {
+        return version;
+    }
 
-  @DataBoundSetter
-  public void setVersion(boolean version) {
-    this.version = version;
-  }
+    @DataBoundSetter
+    public void setVersion(boolean version) {
+        this.version = version;
+    }
 
-  public boolean isArchitectureName() {
-    return architectureName;
-  }
+    public boolean isArchitectureName() {
+        return architectureName;
+    }
 
-  @DataBoundSetter
-  public void setArchitectureName(boolean archName) {
-    this.architectureName = archName;
-  }
+    @DataBoundSetter
+    public void setArchitectureName(boolean archName) {
+        this.architectureName = archName;
+    }
 
-  public boolean isNameVersion() {
-    return nameVersion;
-  }
+    public boolean isNameVersion() {
+        return nameVersion;
+    }
 
-  @DataBoundSetter
-  public void setNameVersion(boolean nameVersion) {
-    this.nameVersion = nameVersion;
-  }
+    @DataBoundSetter
+    public void setNameVersion(boolean nameVersion) {
+        this.nameVersion = nameVersion;
+    }
 
-  public boolean isArchitectureNameVersion() {
-    return architectureNameVersion;
-  }
+    public boolean isArchitectureNameVersion() {
+        return architectureNameVersion;
+    }
 
-  @DataBoundSetter
-  public void setArchitectureNameVersion(boolean archNameVersion) {
-    this.architectureNameVersion = archNameVersion;
-  }
+    @DataBoundSetter
+    public void setArchitectureNameVersion(boolean archNameVersion) {
+        this.architectureNameVersion = archNameVersion;
+    }
 
-  @Extension
-  @Symbol("platformlabelerconfig")
-  public static class DescriptorImpl extends Descriptor<LabelConfig> {
-    /* Intentionally empty constructor */
-  }
+    @Extension
+    @Symbol("platformlabelerconfig")
+    public static class DescriptorImpl extends Descriptor<LabelConfig> {
+        /* Intentionally empty constructor */
+    }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -37,69 +37,68 @@ import java.util.Map;
 
 /** Linux standard base release class. Provides distributor ID and release. */
 public class LsbRelease {
-  @NonNull private final String distributorId;
-  @NonNull private final String release;
+    @NonNull private final String distributorId;
+    @NonNull private final String release;
 
-  /** Extract distributor ID and release for current platform. */
-  public LsbRelease() {
-    Map<String, String> newProps = new HashMap<>();
-    try {
-      Process process = new ProcessBuilder("lsb_release", "-a").start();
-      readLsbReleaseOutput(process.getInputStream(), newProps);
-    } catch (IOException e) {
-      // IGNORE
+    /** Extract distributor ID and release for current platform. */
+    public LsbRelease() {
+        Map<String, String> newProps = new HashMap<>();
+        try {
+            Process process = new ProcessBuilder("lsb_release", "-a").start();
+            readLsbReleaseOutput(process.getInputStream(), newProps);
+        } catch (IOException e) {
+            // IGNORE
+        }
+        this.distributorId =
+                newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        this.release = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
     }
-    this.distributorId =
-        newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-    this.release = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-  }
 
-  /** Assign distributor ID and release. Package protected for tests. */
-  LsbRelease(String distributorId, String release) {
-    this.distributorId = distributorId;
-    this.release = release;
-  }
-
-  /** Read file to assign distributor ID and release. Package protected for tests. */
-  LsbRelease(File lsbReleaseFile) throws IOException {
-    Map<String, String> newProps = new HashMap<>();
-    try (FileInputStream stream = new FileInputStream(lsbReleaseFile)) {
-      readLsbReleaseOutput(stream, newProps);
+    /** Assign distributor ID and release. Package protected for tests. */
+    LsbRelease(String distributorId, String release) {
+        this.distributorId = distributorId;
+        this.release = release;
     }
-    this.distributorId =
-        newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-    this.release = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-  }
 
-  private void readLsbReleaseOutput(InputStream inputStream, Map<String, String> newProps)
-      throws IOException {
-    try (BufferedReader reader =
-        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-      reader
-          .lines()
-          .filter(s -> s.contains(":"))
-          .map(line -> line.split(":", 2))
-          .forEach(parts -> newProps.put(parts[0], parts[1].trim()));
+    /** Read file to assign distributor ID and release. Package protected for tests. */
+    LsbRelease(File lsbReleaseFile) throws IOException {
+        Map<String, String> newProps = new HashMap<>();
+        try (FileInputStream stream = new FileInputStream(lsbReleaseFile)) {
+            readLsbReleaseOutput(stream, newProps);
+        }
+        this.distributorId =
+                newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        this.release = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
     }
-  }
 
-  /**
-   * Return the Linux distributor ID for this agent.
-   *
-   * @return Linux distributor ID for this agent
-   */
-  @NonNull
-  public String distributorId() {
-    return distributorId;
-  }
+    private void readLsbReleaseOutput(InputStream inputStream, Map<String, String> newProps)
+            throws IOException {
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            reader.lines()
+                    .filter(s -> s.contains(":"))
+                    .map(line -> line.split(":", 2))
+                    .forEach(parts -> newProps.put(parts[0], parts[1].trim()));
+        }
+    }
 
-  /**
-   * Return the Linux release for this agent.
-   *
-   * @return Linux release for this agent
-   */
-  @NonNull
-  public String release() {
-    return release;
-  }
+    /**
+     * Return the Linux distributor ID for this agent.
+     *
+     * @return Linux distributor ID for this agent
+     */
+    @NonNull
+    public String distributorId() {
+        return distributorId;
+    }
+
+    /**
+     * Return the Linux release for this agent.
+     *
+     * @return Linux release for this agent
+     */
+    @NonNull
+    public String release() {
+        return release;
+    }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -5,52 +5,52 @@ import java.io.Serializable;
 /** Stores the platform details of a node. */
 public class PlatformDetails implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-  private final String name;
-  private final String architecture;
-  private final String version;
-  private final String architectureNameVersion;
-  private final String architectureName;
-  private final String nameVersion;
+    private final String name;
+    private final String architecture;
+    private final String version;
+    private final String architectureNameVersion;
+    private final String architectureName;
+    private final String nameVersion;
 
-  /**
-   * Platform details constructor.
-   *
-   * @param name name of operating system, as in windows, debian, ubuntu, etc.
-   * @param architecture hardware architecture, as in amd64, aarh64, etc.
-   * @param version version of operating system, as in 9.1, 14.04, etc.
-   */
-  public PlatformDetails(String name, String architecture, String version) {
-    this.name = name;
-    this.architecture = architecture;
-    this.version = version;
-    architectureNameVersion = architecture + "-" + name + "-" + version;
-    architectureName = architecture + "-" + name;
-    nameVersion = name + "-" + version;
-  }
+    /**
+     * Platform details constructor.
+     *
+     * @param name name of operating system, as in windows, debian, ubuntu, etc.
+     * @param architecture hardware architecture, as in amd64, aarh64, etc.
+     * @param version version of operating system, as in 9.1, 14.04, etc.
+     */
+    public PlatformDetails(String name, String architecture, String version) {
+        this.name = name;
+        this.architecture = architecture;
+        this.version = version;
+        architectureNameVersion = architecture + "-" + name + "-" + version;
+        architectureName = architecture + "-" + name;
+        nameVersion = name + "-" + version;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public String getName() {
+        return name;
+    }
 
-  public String getArchitecture() {
-    return architecture;
-  }
+    public String getArchitecture() {
+        return architecture;
+    }
 
-  public String getVersion() {
-    return version;
-  }
+    public String getVersion() {
+        return version;
+    }
 
-  public String getArchitectureNameVersion() {
-    return architectureNameVersion;
-  }
+    public String getArchitectureNameVersion() {
+        return architectureNameVersion;
+    }
 
-  public String getArchitectureName() {
-    return architectureName;
-  }
+    public String getArchitectureName() {
+        return architectureName;
+    }
 
-  public String getNameVersion() {
-    return nameVersion;
-  }
+    public String getNameVersion() {
+        return nameVersion;
+    }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -47,425 +47,432 @@ import org.jenkinsci.remoting.RoleChecker;
 /** Compute labels based on details computed on the agent. */
 class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
 
-  private static final String RELEASE = "release";
-  private static final String VERSION = "VERSION =";
-  private static final String PATCHLEVEL = "PATCHLEVEL =";
-  /** Unknown field value string. Package protected for us by LsbRelease class */
-  static final String UNKNOWN_VALUE_STRING = "unknown+check_lsb_release_installed";
+    private static final String RELEASE = "release";
+    private static final String VERSION = "VERSION =";
+    private static final String PATCHLEVEL = "PATCHLEVEL =";
+    /** Unknown field value string. Package protected for us by LsbRelease class */
+    static final String UNKNOWN_VALUE_STRING = "unknown+check_lsb_release_installed";
 
-  // Added Apr 16, 2020 to resolve spotbugs warning
-  private static final long serialVersionUID = 2020 - 04 - 16;
+    // Added Apr 16, 2020 to resolve spotbugs warning
+    private static final long serialVersionUID = 2020 - 04 - 16;
 
-  /**
-   * Checks that required SLAVE role is allowed.
-   *
-   * @param checker role checker to be called to check SLAVE role
-   * @throws SecurityException on a security error
-   */
-  @Override
-  public void checkRoles(final RoleChecker checker) throws SecurityException {
-    checker.check(this, Roles.SLAVE);
-  }
-
-  /**
-   * Performs label computation and returns the result as a HashSet.
-   *
-   * @return label computation result
-   * @throws IOException on I/O error
-   */
-  @Override
-  public PlatformDetails call() throws IOException {
-    final String arch = System.getProperty("os.arch", UNKNOWN_VALUE_STRING);
-    final String name = System.getProperty("os.name", UNKNOWN_VALUE_STRING);
-    final String version = System.getProperty("os.version", UNKNOWN_VALUE_STRING);
-    return computeLabels(arch, name, version);
-  }
-
-  @SuppressFBWarnings(
-      value = "IMPROPER_UNICODE",
-      justification = "Strings are ASCII, safe to ignore case")
-  private boolean equalsIgnoreCase(@NonNull String s1, @NonNull String s2) {
-    return s1.equalsIgnoreCase(s2);
-  }
-
-  /**
-   * Returns standardized architecture of current Windows operating system, adapted for those cases
-   * where a 64 bit machine may be running a 32 bit Java virtual machine. Returns "amd64" if the
-   * processor environment variables report this is an AMD 64 architecture (modern Intel and AMD
-   * processors).
-   *
-   * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
-   * @return standardized architecture of current Windows operating system
-   */
-  @NonNull
-  protected String checkWindows32Bit(
-      @NonNull final String arch, @NonNull final String env1, @NonNull final String env2) {
-    if (!equalsIgnoreCase("x86", arch)) {
-      return arch;
+    /**
+     * Checks that required SLAVE role is allowed.
+     *
+     * @param checker role checker to be called to check SLAVE role
+     * @throws SecurityException on a security error
+     */
+    @Override
+    public void checkRoles(final RoleChecker checker) throws SecurityException {
+        checker.check(this, Roles.SLAVE);
     }
-    if (equalsIgnoreCase("amd64", env1) || equalsIgnoreCase("amd64", env2)) {
-      return "amd64";
-    }
-    return arch;
-  }
 
-  /**
-   * Returns standardized architecture of current Linux operating system, adapted for those cases
-   * where a 64 bit machine may identify architecture in different ways. Returns "amd64" if the
-   * 'uname -m' output is "x86_64".
-   *
-   * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
-   * @return standardized architecture of current Linux operating system
-   */
-  @NonNull
-  private String getCanonicalLinuxArch(@NonNull final String arch) {
-    if (!equalsIgnoreCase("x86", arch)) {
-      return arch;
+    /**
+     * Performs label computation and returns the result as a HashSet.
+     *
+     * @return label computation result
+     * @throws IOException on I/O error
+     */
+    @Override
+    public PlatformDetails call() throws IOException {
+        final String arch = System.getProperty("os.arch", UNKNOWN_VALUE_STRING);
+        final String name = System.getProperty("os.name", UNKNOWN_VALUE_STRING);
+        final String version = System.getProperty("os.version", UNKNOWN_VALUE_STRING);
+        return computeLabels(arch, name, version);
     }
-    try {
-      Process p = Runtime.getRuntime().exec("/bin/uname -m");
-      p.waitFor();
-      return getCanonicalLinuxArchStream(p.getInputStream(), arch);
-    } catch (IOException | InterruptedException e) {
-      /* Return arch instead of throwing an exception */
-    }
-    return arch;
-  }
 
-  /* Package protected for testing */
-  String getCanonicalLinuxArchStream(@NonNull InputStream stream, @NonNull String arch)
-      throws IOException {
-    try (BufferedReader b = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
-      String line = b.readLine();
-      if (line != null) {
-        if ("x86_64".equals(line)) {
-          return "amd64";
-        } else {
-          return line;
+    @SuppressFBWarnings(
+            value = "IMPROPER_UNICODE",
+            justification = "Strings are ASCII, safe to ignore case")
+    private boolean equalsIgnoreCase(@NonNull String s1, @NonNull String s2) {
+        return s1.equalsIgnoreCase(s2);
+    }
+
+    /**
+     * Returns standardized architecture of current Windows operating system, adapted for those
+     * cases where a 64 bit machine may be running a 32 bit Java virtual machine. Returns "amd64" if
+     * the processor environment variables report this is an AMD 64 architecture (modern Intel and
+     * AMD processors).
+     *
+     * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
+     * @return standardized architecture of current Windows operating system
+     */
+    @NonNull
+    protected String checkWindows32Bit(
+            @NonNull final String arch, @NonNull final String env1, @NonNull final String env2) {
+        if (!equalsIgnoreCase("x86", arch)) {
+            return arch;
         }
-      }
+        if (equalsIgnoreCase("amd64", env1) || equalsIgnoreCase("amd64", env2)) {
+            return "amd64";
+        }
+        return arch;
     }
-    return arch;
-  }
 
-  /**
-   * Compute agent OS properties based on seed values provided as parameters.
-   *
-   * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
-   * @param name name of the operating system or distribution as in "OpenBSD", "FreeBSD", "Windows",
-   *     or "Linux"
-   * @param version version of the operating system
-   * @return agent OS properties
-   * @throws IOException on I/O error
-   */
-  @NonNull
-  protected PlatformDetails computeLabels(
-      @NonNull final String arch, @NonNull final String name, @NonNull final String version)
-      throws IOException {
-    LsbRelease release;
-    if (name.toLowerCase(Locale.ENGLISH).startsWith("linux")) {
-      release = new LsbRelease();
-    } else {
-      release = null;
-    }
-    return computeLabels(arch, name, version, release);
-  }
-
-  @SuppressFBWarnings(
-      value = "IMPROPER_UNICODE",
-      justification = "Strings are ASCII, safe to lower case")
-  private String toLowerCase(@NonNull String s1) {
-    return s1.toLowerCase(Locale.ENGLISH);
-  }
-
-  /**
-   * Compute agent OS properties based on seed values provided as parameters.
-   *
-   * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
-   * @param name name of the operating system or distribution as in "OpenBSD", "FreeBSD", "Windows",
-   *     or "Linux"
-   * @param version version of the operating system
-   * @param release Linux standard base release data (name, distributorId, version, etc.)
-   * @return agent labels as a set of strings
-   * @throws IOException on I/O error
-   */
-  @NonNull
-  protected PlatformDetails computeLabels(
-      @NonNull final String arch,
-      @NonNull final String name,
-      @NonNull final String version,
-      @CheckForNull LsbRelease release)
-      throws IOException {
-    String computedName = toLowerCase(name);
-    String computedArch = arch;
-    String computedVersion = version;
-    if (computedName.startsWith("windows")) {
-      computedName = "windows";
-      computedArch =
-          checkWindows32Bit(
-              computedArch,
-              System.getenv("PROCESSOR_ARCHITECTURE"),
-              System.getenv("PROCESSOR_ARCHITEW6432"));
-      if (computedVersion.startsWith("4.0")) {
-        computedVersion = "nt4";
-      } else if (computedVersion.startsWith("5.0")) {
-        computedVersion = "2000";
-      } else if (computedVersion.startsWith("5.1")) {
-        computedVersion = "xp";
-      } else if (computedVersion.startsWith("5.2")) {
-        computedVersion = "2003";
-      }
-    } else if (computedName.startsWith("linux")) {
-      if (release == null) {
-        release = new LsbRelease();
-      }
-      computedName = release.distributorId();
-      computedArch = getCanonicalLinuxArch(computedArch);
-      computedVersion = release.release();
-      /* Fallback to /etc/os-release file */
-      if (computedName.equals(UNKNOWN_VALUE_STRING)) {
-        computedName = getReleaseIdentifier("ID");
-      }
-      if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
-        computedVersion = getReleaseIdentifier("VERSION_ID");
-      }
-      if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
-        computedVersion = getReleaseIdentifier("BUILD_ID");
-      }
-      if (computedName.equals(UNKNOWN_VALUE_STRING)) {
-        computedName = getRedhatReleaseIdentifier("ID");
-      }
-      if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
-        computedVersion = getRedhatReleaseIdentifier("VERSION_ID");
-      }
-      if (equalsIgnoreCase(computedName, "debian")
-          && computedVersion.equals(UNKNOWN_VALUE_STRING)) {
-        /* Debian unstable and Debian testing don't include version in os-release */
-        /* Try reading it from a different location */
-        computedVersion = getDebianVersionIdentifier();
-      }
-      /* JENKINS-64324 notes that labels with '/' break various Jenkins components */
-      /* For example, Debian testing reports its version as "testing/unstable" */
-      /* Take the portion of the version string that precedes the '/' character */
-      if (computedVersion.contains("/")) {
-        int slashLocation = computedVersion.indexOf("/");
-        computedVersion = computedVersion.substring(0, slashLocation);
-      }
-      if (computedName.equals(UNKNOWN_VALUE_STRING)) {
-        computedName = getSuseReleaseIdentifier("ID");
-      }
-      /* This is kind of a hack. lsb_release -a returns only the major
-       * version on SLES 11 and older, so trying to fall back to
-       * reading SuSE-release file to get a more detailed version
-       * including the SP Up to SLES 12 SP1, lsb_release returned
-       * "SUSE LINUX" as ID. As spaces in labels make label management
-       * more complex and we want to have the same label on SUSE Linux
-       * whether running SUSE 11 or SUSE 12 SP3+, we replace "SUSE
-       * LINUX" with "SUSE".
-       */
-      if (computedName.equals("SUSE LINUX")) {
-        computedName = "SUSE";
+    /**
+     * Returns standardized architecture of current Linux operating system, adapted for those cases
+     * where a 64 bit machine may identify architecture in different ways. Returns "amd64" if the
+     * 'uname -m' output is "x86_64".
+     *
+     * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
+     * @return standardized architecture of current Linux operating system
+     */
+    @NonNull
+    private String getCanonicalLinuxArch(@NonNull final String arch) {
+        if (!equalsIgnoreCase("x86", arch)) {
+            return arch;
+        }
         try {
-          int intVersion = Integer.parseInt(computedVersion);
-          if (intVersion <= 11) {
-            String newVersion = getSuseReleaseIdentifier("VERSION_ID");
-            if (!newVersion.equals(UNKNOWN_VALUE_STRING)) {
-              computedVersion = newVersion;
+            Process p = Runtime.getRuntime().exec("/bin/uname -m");
+            p.waitFor();
+            return getCanonicalLinuxArchStream(p.getInputStream(), arch);
+        } catch (IOException | InterruptedException e) {
+            /* Return arch instead of throwing an exception */
+        }
+        return arch;
+    }
+
+    /* Package protected for testing */
+    String getCanonicalLinuxArchStream(@NonNull InputStream stream, @NonNull String arch)
+            throws IOException {
+        try (BufferedReader b = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
+            String line = b.readLine();
+            if (line != null) {
+                if ("x86_64".equals(line)) {
+                    return "amd64";
+                } else {
+                    return line;
+                }
             }
-          }
-        } catch (NumberFormatException nfe) {
-          // Ignore NumberFormatException
         }
-      }
-      if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
-        computedVersion = getSuseReleaseIdentifier("VERSION_ID");
-      }
-    } else if (computedName.startsWith("freebsd")) {
-      computedVersion = getFreeBsdVersion(computedVersion);
-    } else if (computedName.startsWith("mac")) {
-      computedName = "mac";
+        return arch;
     }
-    PlatformDetails properties = new PlatformDetails(computedName, computedArch, computedVersion);
-    return properties;
-  }
 
-  /**
-   * Maps the ID string from /etc/os-release and /etc/redhat-release to the Distributor ID value.
-   * Matches output by lsb_release -a so that users have the same operating system name in the label
-   * whether the label was generated using os-release or using lsb_release.
-   */
-  private static final Map<String, String> PREFERRED_LINUX_OS_NAMES = new HashMap<>();
-
-  static {
-    PREFERRED_LINUX_OS_NAMES.put("alpine", "Alpine");
-    PREFERRED_LINUX_OS_NAMES.put("amzn", "Amazon");
-    PREFERRED_LINUX_OS_NAMES.put("centos", "CentOS");
-    PREFERRED_LINUX_OS_NAMES.put("debian", "Debian");
-    PREFERRED_LINUX_OS_NAMES.put("fedora", "Fedora");
-    PREFERRED_LINUX_OS_NAMES.put("linuxmint", "LinuxMint");
-    PREFERRED_LINUX_OS_NAMES.put("ol", "OracleServer");
-    PREFERRED_LINUX_OS_NAMES.put("opensuse", "openSUSE");
-    PREFERRED_LINUX_OS_NAMES.put("opensuse-leap", "openSUSE");
-    PREFERRED_LINUX_OS_NAMES.put("opensuse-tumbleweed", "openSUSE");
-    PREFERRED_LINUX_OS_NAMES.put("raspbian", "Raspbian");
-    PREFERRED_LINUX_OS_NAMES.put("Red Hat Enterprise Linux", "RedHatEnterprise");
-    PREFERRED_LINUX_OS_NAMES.put("Red Hat Enterprise Linux Server", "RedHatEnterprise");
-    PREFERRED_LINUX_OS_NAMES.put("rhel", "RedHatEnterprise");
-    PREFERRED_LINUX_OS_NAMES.put("sles", "SUSE");
-    PREFERRED_LINUX_OS_NAMES.put("SUSE Linux Enterprise Server", "SUSE");
-    PREFERRED_LINUX_OS_NAMES.put("Scientific Linux", "Scientific");
-    PREFERRED_LINUX_OS_NAMES.put("scientific", "Scientific");
-    PREFERRED_LINUX_OS_NAMES.put("ubuntu", "Ubuntu");
-  }
-
-  private File osRelease = new File("/etc/os-release");
-  private File debianVersion = new File("/etc/debian_version");
-  private File redhatRelease = new File("/etc/redhat-release");
-  private File suseRelease = new File("/etc/SuSE-release");
-
-  /* Package protected for use in tests */
-  void setOsReleaseFile(File osRelease) {
-    this.osRelease = osRelease;
-  }
-
-  void setRedhatRelease(File redhatRelease) {
-    this.redhatRelease = redhatRelease;
-  }
-
-  void setSuseRelease(File suseRelease) {
-    this.suseRelease = suseRelease;
-  }
-
-  void setDebianVersion(File debianVersion) {
-    this.debianVersion = debianVersion;
-  }
-
-  /* Package protected for use in tests */
-  @NonNull
-  String getReleaseIdentifier(@NonNull String field) {
-    String value = UNKNOWN_VALUE_STRING;
-    if (osRelease == null) {
-      return value;
-    }
-    try (BufferedReader br =
-        new BufferedReader(Files.newBufferedReader(osRelease.toPath(), StandardCharsets.UTF_8))) {
-      String line;
-      while ((line = br.readLine()) != null) {
-        if (line.startsWith(field + "=")) {
-          String[] parts = line.split("=");
-          value = parts[1].replace("\"", "").trim();
+    /**
+     * Compute agent OS properties based on seed values provided as parameters.
+     *
+     * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
+     * @param name name of the operating system or distribution as in "OpenBSD", "FreeBSD",
+     *     "Windows", or "Linux"
+     * @param version version of the operating system
+     * @return agent OS properties
+     * @throws IOException on I/O error
+     */
+    @NonNull
+    protected PlatformDetails computeLabels(
+            @NonNull final String arch, @NonNull final String name, @NonNull final String version)
+            throws IOException {
+        LsbRelease release;
+        if (name.toLowerCase(Locale.ENGLISH).startsWith("linux")) {
+            release = new LsbRelease();
+        } else {
+            release = null;
         }
-      }
-    } catch (IOException notFound) {
-      // Ignore IOException
+        return computeLabels(arch, name, version, release);
     }
-    return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
-  }
 
-  /* Package protected for use in tests */
-  @NonNull
-  String getRedhatReleaseIdentifier(@NonNull String field) {
-    String value = UNKNOWN_VALUE_STRING;
-    if (redhatRelease == null) {
-      return value;
+    @SuppressFBWarnings(
+            value = "IMPROPER_UNICODE",
+            justification = "Strings are ASCII, safe to lower case")
+    private String toLowerCase(@NonNull String s1) {
+        return s1.toLowerCase(Locale.ENGLISH);
     }
-    try (BufferedReader br =
-        new BufferedReader(
-            Files.newBufferedReader(redhatRelease.toPath(), StandardCharsets.UTF_8))) {
-      String line;
-      while ((line = br.readLine()) != null) {
-        if (line.contains(RELEASE)) {
-          if (field.equals("ID")) {
-            value = line.substring(0, line.indexOf(RELEASE)).trim();
-          }
-          if (field.equals("VERSION_ID")) {
-            value =
-                line.substring(line.indexOf(RELEASE) + RELEASE.length(), line.indexOf("(")).trim();
-          }
-        }
-      }
-    } catch (IOException notFound) {
-      // Ignore IOException
-    }
-    return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
-  }
 
-  @NonNull
-  String getSuseReleaseIdentifier(@NonNull String field) {
-    String value = UNKNOWN_VALUE_STRING;
-    String version = null;
-    String patchLevel = null;
-    String name = UNKNOWN_VALUE_STRING;
-    Pattern pattern = Pattern.compile("^(SUSE.*?)\\d+.*$");
-    if (suseRelease == null) {
-      return value;
-    }
-    try (BufferedReader br =
-        new BufferedReader(Files.newBufferedReader(suseRelease.toPath(), StandardCharsets.UTF_8))) {
-      String line;
-      while ((line = br.readLine()) != null) {
-        if (line.startsWith(VERSION)) {
-          version = line.substring(VERSION.length()).trim();
+    /**
+     * Compute agent OS properties based on seed values provided as parameters.
+     *
+     * @param arch architecture of the agent, as in "x86", "amd64", or "aarch64"
+     * @param name name of the operating system or distribution as in "OpenBSD", "FreeBSD",
+     *     "Windows", or "Linux"
+     * @param version version of the operating system
+     * @param release Linux standard base release data (name, distributorId, version, etc.)
+     * @return agent labels as a set of strings
+     * @throws IOException on I/O error
+     */
+    @NonNull
+    protected PlatformDetails computeLabels(
+            @NonNull final String arch,
+            @NonNull final String name,
+            @NonNull final String version,
+            @CheckForNull LsbRelease release)
+            throws IOException {
+        String computedName = toLowerCase(name);
+        String computedArch = arch;
+        String computedVersion = version;
+        if (computedName.startsWith("windows")) {
+            computedName = "windows";
+            computedArch =
+                    checkWindows32Bit(
+                            computedArch,
+                            System.getenv("PROCESSOR_ARCHITECTURE"),
+                            System.getenv("PROCESSOR_ARCHITEW6432"));
+            if (computedVersion.startsWith("4.0")) {
+                computedVersion = "nt4";
+            } else if (computedVersion.startsWith("5.0")) {
+                computedVersion = "2000";
+            } else if (computedVersion.startsWith("5.1")) {
+                computedVersion = "xp";
+            } else if (computedVersion.startsWith("5.2")) {
+                computedVersion = "2003";
+            }
+        } else if (computedName.startsWith("linux")) {
+            if (release == null) {
+                release = new LsbRelease();
+            }
+            computedName = release.distributorId();
+            computedArch = getCanonicalLinuxArch(computedArch);
+            computedVersion = release.release();
+            /* Fallback to /etc/os-release file */
+            if (computedName.equals(UNKNOWN_VALUE_STRING)) {
+                computedName = getReleaseIdentifier("ID");
+            }
+            if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
+                computedVersion = getReleaseIdentifier("VERSION_ID");
+            }
+            if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
+                computedVersion = getReleaseIdentifier("BUILD_ID");
+            }
+            if (computedName.equals(UNKNOWN_VALUE_STRING)) {
+                computedName = getRedhatReleaseIdentifier("ID");
+            }
+            if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
+                computedVersion = getRedhatReleaseIdentifier("VERSION_ID");
+            }
+            if (equalsIgnoreCase(computedName, "debian")
+                    && computedVersion.equals(UNKNOWN_VALUE_STRING)) {
+                /* Debian unstable and Debian testing don't include version in os-release */
+                /* Try reading it from a different location */
+                computedVersion = getDebianVersionIdentifier();
+            }
+            /* JENKINS-64324 notes that labels with '/' break various Jenkins components */
+            /* For example, Debian testing reports its version as "testing/unstable" */
+            /* Take the portion of the version string that precedes the '/' character */
+            if (computedVersion.contains("/")) {
+                int slashLocation = computedVersion.indexOf("/");
+                computedVersion = computedVersion.substring(0, slashLocation);
+            }
+            if (computedName.equals(UNKNOWN_VALUE_STRING)) {
+                computedName = getSuseReleaseIdentifier("ID");
+            }
+            /* This is kind of a hack. lsb_release -a returns only the major
+             * version on SLES 11 and older, so trying to fall back to
+             * reading SuSE-release file to get a more detailed version
+             * including the SP Up to SLES 12 SP1, lsb_release returned
+             * "SUSE LINUX" as ID. As spaces in labels make label management
+             * more complex and we want to have the same label on SUSE Linux
+             * whether running SUSE 11 or SUSE 12 SP3+, we replace "SUSE
+             * LINUX" with "SUSE".
+             */
+            if (computedName.equals("SUSE LINUX")) {
+                computedName = "SUSE";
+                try {
+                    int intVersion = Integer.parseInt(computedVersion);
+                    if (intVersion <= 11) {
+                        String newVersion = getSuseReleaseIdentifier("VERSION_ID");
+                        if (!newVersion.equals(UNKNOWN_VALUE_STRING)) {
+                            computedVersion = newVersion;
+                        }
+                    }
+                } catch (NumberFormatException nfe) {
+                    // Ignore NumberFormatException
+                }
+            }
+            if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
+                computedVersion = getSuseReleaseIdentifier("VERSION_ID");
+            }
+        } else if (computedName.startsWith("freebsd")) {
+            computedVersion = getFreeBsdVersion(computedVersion);
+        } else if (computedName.startsWith("mac")) {
+            computedName = "mac";
         }
-        if (line.startsWith(PATCHLEVEL)) {
-          patchLevel = line.substring(PATCHLEVEL.length()).trim();
-        }
-        Matcher matcher = pattern.matcher(line.trim());
-        if (matcher.matches()) {
-          name = matcher.group(1).trim();
-        }
-      }
-    } catch (IOException notFound) {
-      return value;
+        PlatformDetails properties =
+                new PlatformDetails(computedName, computedArch, computedVersion);
+        return properties;
     }
-    if (field.equals("ID")) {
-      value = name;
-    }
-    if (field.equals("VERSION_ID")) {
-      if (version == null) {
-        return value;
-      } else {
-        value = version;
-        if (patchLevel != null) {
-          value += "." + patchLevel;
-        }
-      }
-    }
-    return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
-  }
 
-  @NonNull
-  String getDebianVersionIdentifier() {
-    if (debianVersion != null) {
-      try (BufferedReader br =
-          new BufferedReader(
-              Files.newBufferedReader(debianVersion.toPath(), StandardCharsets.UTF_8))) {
-        String line;
-        while ((line = br.readLine()) != null) {
-          return line.trim();
+    /**
+     * Maps the ID string from /etc/os-release and /etc/redhat-release to the Distributor ID value.
+     * Matches output by lsb_release -a so that users have the same operating system name in the
+     * label whether the label was generated using os-release or using lsb_release.
+     */
+    private static final Map<String, String> PREFERRED_LINUX_OS_NAMES = new HashMap<>();
+
+    static {
+        PREFERRED_LINUX_OS_NAMES.put("alpine", "Alpine");
+        PREFERRED_LINUX_OS_NAMES.put("amzn", "Amazon");
+        PREFERRED_LINUX_OS_NAMES.put("centos", "CentOS");
+        PREFERRED_LINUX_OS_NAMES.put("debian", "Debian");
+        PREFERRED_LINUX_OS_NAMES.put("fedora", "Fedora");
+        PREFERRED_LINUX_OS_NAMES.put("linuxmint", "LinuxMint");
+        PREFERRED_LINUX_OS_NAMES.put("ol", "OracleServer");
+        PREFERRED_LINUX_OS_NAMES.put("opensuse", "openSUSE");
+        PREFERRED_LINUX_OS_NAMES.put("opensuse-leap", "openSUSE");
+        PREFERRED_LINUX_OS_NAMES.put("opensuse-tumbleweed", "openSUSE");
+        PREFERRED_LINUX_OS_NAMES.put("raspbian", "Raspbian");
+        PREFERRED_LINUX_OS_NAMES.put("Red Hat Enterprise Linux", "RedHatEnterprise");
+        PREFERRED_LINUX_OS_NAMES.put("Red Hat Enterprise Linux Server", "RedHatEnterprise");
+        PREFERRED_LINUX_OS_NAMES.put("rhel", "RedHatEnterprise");
+        PREFERRED_LINUX_OS_NAMES.put("sles", "SUSE");
+        PREFERRED_LINUX_OS_NAMES.put("SUSE Linux Enterprise Server", "SUSE");
+        PREFERRED_LINUX_OS_NAMES.put("Scientific Linux", "Scientific");
+        PREFERRED_LINUX_OS_NAMES.put("scientific", "Scientific");
+        PREFERRED_LINUX_OS_NAMES.put("ubuntu", "Ubuntu");
+    }
+
+    private File osRelease = new File("/etc/os-release");
+    private File debianVersion = new File("/etc/debian_version");
+    private File redhatRelease = new File("/etc/redhat-release");
+    private File suseRelease = new File("/etc/SuSE-release");
+
+    /* Package protected for use in tests */
+    void setOsReleaseFile(File osRelease) {
+        this.osRelease = osRelease;
+    }
+
+    void setRedhatRelease(File redhatRelease) {
+        this.redhatRelease = redhatRelease;
+    }
+
+    void setSuseRelease(File suseRelease) {
+        this.suseRelease = suseRelease;
+    }
+
+    void setDebianVersion(File debianVersion) {
+        this.debianVersion = debianVersion;
+    }
+
+    /* Package protected for use in tests */
+    @NonNull
+    String getReleaseIdentifier(@NonNull String field) {
+        String value = UNKNOWN_VALUE_STRING;
+        if (osRelease == null) {
+            return value;
         }
-      } catch (IOException notFound) {
+        try (BufferedReader br =
+                new BufferedReader(
+                        Files.newBufferedReader(osRelease.toPath(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith(field + "=")) {
+                    String[] parts = line.split("=");
+                    value = parts[1].replace("\"", "").trim();
+                }
+            }
+        } catch (IOException notFound) {
+            // Ignore IOException
+        }
+        return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
+    }
+
+    /* Package protected for use in tests */
+    @NonNull
+    String getRedhatReleaseIdentifier(@NonNull String field) {
+        String value = UNKNOWN_VALUE_STRING;
+        if (redhatRelease == null) {
+            return value;
+        }
+        try (BufferedReader br =
+                new BufferedReader(
+                        Files.newBufferedReader(redhatRelease.toPath(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains(RELEASE)) {
+                    if (field.equals("ID")) {
+                        value = line.substring(0, line.indexOf(RELEASE)).trim();
+                    }
+                    if (field.equals("VERSION_ID")) {
+                        value =
+                                line.substring(
+                                                line.indexOf(RELEASE) + RELEASE.length(),
+                                                line.indexOf("("))
+                                        .trim();
+                    }
+                }
+            }
+        } catch (IOException notFound) {
+            // Ignore IOException
+        }
+        return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
+    }
+
+    @NonNull
+    String getSuseReleaseIdentifier(@NonNull String field) {
+        String value = UNKNOWN_VALUE_STRING;
+        String version = null;
+        String patchLevel = null;
+        String name = UNKNOWN_VALUE_STRING;
+        Pattern pattern = Pattern.compile("^(SUSE.*?)\\d+.*$");
+        if (suseRelease == null) {
+            return value;
+        }
+        try (BufferedReader br =
+                new BufferedReader(
+                        Files.newBufferedReader(suseRelease.toPath(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith(VERSION)) {
+                    version = line.substring(VERSION.length()).trim();
+                }
+                if (line.startsWith(PATCHLEVEL)) {
+                    patchLevel = line.substring(PATCHLEVEL.length()).trim();
+                }
+                Matcher matcher = pattern.matcher(line.trim());
+                if (matcher.matches()) {
+                    name = matcher.group(1).trim();
+                }
+            }
+        } catch (IOException notFound) {
+            return value;
+        }
+        if (field.equals("ID")) {
+            value = name;
+        }
+        if (field.equals("VERSION_ID")) {
+            if (version == null) {
+                return value;
+            } else {
+                value = version;
+                if (patchLevel != null) {
+                    value += "." + patchLevel;
+                }
+            }
+        }
+        return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
+    }
+
+    @NonNull
+    String getDebianVersionIdentifier() {
+        if (debianVersion != null) {
+            try (BufferedReader br =
+                    new BufferedReader(
+                            Files.newBufferedReader(
+                                    debianVersion.toPath(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    return line.trim();
+                }
+            } catch (IOException notFound) {
+                return UNKNOWN_VALUE_STRING;
+            }
+        }
         return UNKNOWN_VALUE_STRING;
-      }
     }
-    return UNKNOWN_VALUE_STRING;
-  }
 
-  @NonNull
-  String getFreeBsdVersion(String version) {
-    try {
-      Process p = Runtime.getRuntime().exec("/bin/freebsd-version -u");
-      p.waitFor();
-      try (BufferedReader b =
-          new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
-        String line = b.readLine();
-        if (line != null) {
-          version = line;
+    @NonNull
+    String getFreeBsdVersion(String version) {
+        try {
+            Process p = Runtime.getRuntime().exec("/bin/freebsd-version -u");
+            p.waitFor();
+            try (BufferedReader b =
+                    new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
+                String line = b.readLine();
+                if (line != null) {
+                    version = line;
+                }
+            }
+        } catch (IOException | InterruptedException e) {
+            /* Return version instead of throwing an exception */
         }
-      }
-    } catch (IOException | InterruptedException e) {
-      /* Return version instead of throwing an exception */
+        return version;
     }
-    return version;
-  }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabeler.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabeler.java
@@ -39,18 +39,18 @@ import java.util.Collections;
 @Extension
 public class PlatformLabeler extends LabelFinder {
 
-  /**
-   * Returns collection of LabelAtom for the node argument.
-   *
-   * @param node agent whose labels are returned
-   * @return collection of LabelAtom for the node argument
-   */
-  @Override
-  public final Collection<LabelAtom> findLabels(final Node node) {
-    Collection<LabelAtom> result = NodeLabelCache.nodeLabels.get(node);
-    if (null == result) /* Node that has just attached and we don't have labels yet */ {
-      return Collections.emptySet();
+    /**
+     * Returns collection of LabelAtom for the node argument.
+     *
+     * @param node agent whose labels are returned
+     * @return collection of LabelAtom for the node argument
+     */
+    @Override
+    public final Collection<LabelAtom> findLabels(final Node node) {
+        Collection<LabelAtom> result = NodeLabelCache.nodeLabels.get(node);
+        if (null == result) /* Node that has just attached and we don't have labels yet */ {
+            return Collections.emptySet();
+        }
+        return result;
     }
-    return result;
-  }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
@@ -13,32 +13,32 @@ import org.kohsuke.stapler.StaplerRequest;
 @Extension
 public class PlatformLabelerGlobalConfiguration extends GlobalConfiguration {
 
-  private LabelConfig labelConfig;
+    private LabelConfig labelConfig;
 
-  /** Standard constructor. */
-  public PlatformLabelerGlobalConfiguration() {
-    load();
-    if (labelConfig == null) {
-      labelConfig = new LabelConfig();
+    /** Standard constructor. */
+    public PlatformLabelerGlobalConfiguration() {
+        load();
+        if (labelConfig == null) {
+            labelConfig = new LabelConfig();
+        }
     }
-  }
 
-  @Override
-  public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
-    boolean result = super.configure(req, json);
-    NodeLabelCache nlc = ComputerListener.all().get(NodeLabelCache.class);
-    if (nlc != null) {
-      nlc.onConfigurationChange();
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        boolean result = super.configure(req, json);
+        NodeLabelCache nlc = ComputerListener.all().get(NodeLabelCache.class);
+        if (nlc != null) {
+            nlc.onConfigurationChange();
+        }
+        return result;
     }
-    return result;
-  }
 
-  public LabelConfig getLabelConfig() {
-    return labelConfig;
-  }
+    public LabelConfig getLabelConfig() {
+        return labelConfig;
+    }
 
-  public void setLabelConfig(LabelConfig labelConfig) {
-    this.labelConfig = labelConfig;
-    save();
-  }
+    public void setLabelConfig(LabelConfig labelConfig) {
+        this.labelConfig = labelConfig;
+        save();
+    }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty.java
@@ -10,28 +10,28 @@ import org.kohsuke.stapler.DataBoundSetter;
 /** Allows to configure which labels should be generate for the node. */
 public class PlatformLabelerNodeProperty extends NodeProperty<Node> {
 
-  private LabelConfig labelConfig;
+    private LabelConfig labelConfig;
 
-  @DataBoundConstructor
-  public PlatformLabelerNodeProperty() {
-    /* Intentionally empty constructor */
-  }
-
-  public LabelConfig getLabelConfig() {
-    return labelConfig;
-  }
-
-  @DataBoundSetter
-  public void setLabelConfig(LabelConfig labelConfig) {
-    this.labelConfig = labelConfig;
-  }
-
-  @Extension
-  public static class DescriptorImpl extends NodePropertyDescriptor {
-
-    @Override
-    public String getDisplayName() {
-      return "Automatic Platform Labels";
+    @DataBoundConstructor
+    public PlatformLabelerNodeProperty() {
+        /* Intentionally empty constructor */
     }
-  }
+
+    public LabelConfig getLabelConfig() {
+        return labelConfig;
+    }
+
+    @DataBoundSetter
+    public void setLabelConfig(LabelConfig labelConfig) {
+        this.labelConfig = labelConfig;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends NodePropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Automatic Platform Labels";
+        }
+    }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -17,154 +17,155 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ConfigurationTest {
-  @Rule public final JenkinsRule r = new JenkinsRule();
+    @Rule public final JenkinsRule r = new JenkinsRule();
 
-  private Computer computer;
-  private NodeLabelCache nodeLabelCache;
-  private PlatformDetails platformDetails;
+    private Computer computer;
+    private NodeLabelCache nodeLabelCache;
+    private PlatformDetails platformDetails;
 
-  @Before
-  public void setUp() throws IOException, InterruptedException {
-    computer = r.jenkins.toComputer();
-    nodeLabelCache = ComputerListener.all().get(NodeLabelCache.class);
-    platformDetails = nodeLabelCache.requestComputerPlatformDetails(computer);
-  }
+    @Before
+    public void setUp() throws IOException, InterruptedException {
+        computer = r.jenkins.toComputer();
+        nodeLabelCache = ComputerListener.all().get(NodeLabelCache.class);
+        platformDetails = nodeLabelCache.requestComputerPlatformDetails(computer);
+    }
 
-  @Test
-  public void configuredNameOnlyLabel() {
-    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
-    LabelConfig labelConfig = new LabelConfig();
-    labelConfig.setArchitecture(false);
-    labelConfig.setArchitectureName(false);
-    labelConfig.setArchitectureNameVersion(false);
-    labelConfig.setVersion(false);
-    labelConfig.setNameVersion(false);
-    nodeProperty.setLabelConfig(labelConfig);
-    r.jenkins.getNodeProperties().add(nodeProperty);
+    @Test
+    public void configuredNameOnlyLabel() {
+        PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+        LabelConfig labelConfig = new LabelConfig();
+        labelConfig.setArchitecture(false);
+        labelConfig.setArchitectureName(false);
+        labelConfig.setArchitectureNameVersion(false);
+        labelConfig.setVersion(false);
+        labelConfig.setNameVersion(false);
+        nodeProperty.setLabelConfig(labelConfig);
+        r.jenkins.getNodeProperties().add(nodeProperty);
 
-    nodeLabelCache.onConfigurationChange();
+        nodeLabelCache.onConfigurationChange();
 
-    Collection<LabelAtom> expected = new HashSet<>();
-    expected.add(r.jenkins.getLabelAtom("master"));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
+        Collection<LabelAtom> expected = new HashSet<>();
+        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
 
-    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(expected, is(labelsAfter));
-  }
+        Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+        assertThat(expected, is(labelsAfter));
+    }
 
-  @Test
-  public void configuredTwoLabels() {
-    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
-    LabelConfig labelConfig = new LabelConfig();
-    labelConfig.setArchitectureName(false);
-    labelConfig.setArchitectureNameVersion(false);
-    labelConfig.setName(false);
-    labelConfig.setNameVersion(false);
-    nodeProperty.setLabelConfig(labelConfig);
-    r.jenkins.getNodeProperties().add(nodeProperty);
+    @Test
+    public void configuredTwoLabels() {
+        PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+        LabelConfig labelConfig = new LabelConfig();
+        labelConfig.setArchitectureName(false);
+        labelConfig.setArchitectureNameVersion(false);
+        labelConfig.setName(false);
+        labelConfig.setNameVersion(false);
+        nodeProperty.setLabelConfig(labelConfig);
+        r.jenkins.getNodeProperties().add(nodeProperty);
 
-    nodeLabelCache.onConfigurationChange();
+        nodeLabelCache.onConfigurationChange();
 
-    Collection<LabelAtom> expected = new HashSet<>();
-    expected.add(r.jenkins.getLabelAtom("master"));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
+        Collection<LabelAtom> expected = new HashSet<>();
+        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
 
-    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(expected, is(labelsAfter));
-  }
+        Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+        assertThat(expected, is(labelsAfter));
+    }
 
-  @Test
-  public void configuredAllLabelsOnNode() {
-    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
-    LabelConfig labelConfig = new LabelConfig();
-    nodeProperty.setLabelConfig(labelConfig);
-    r.jenkins.getNodeProperties().add(nodeProperty);
+    @Test
+    public void configuredAllLabelsOnNode() {
+        PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+        LabelConfig labelConfig = new LabelConfig();
+        nodeProperty.setLabelConfig(labelConfig);
+        r.jenkins.getNodeProperties().add(nodeProperty);
 
-    nodeLabelCache.onConfigurationChange();
+        nodeLabelCache.onConfigurationChange();
 
-    Collection<LabelAtom> expected = new HashSet<>();
-    expected.add(r.jenkins.getLabelAtom("master"));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureName()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
+        Collection<LabelAtom> expected = new HashSet<>();
+        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureName()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
 
-    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(expected, is(labelsAfter));
-  }
+        Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+        assertThat(expected, is(labelsAfter));
+    }
 
-  @Test
-  public void nodeConfigOverridesGlobalConfig() {
+    @Test
+    public void nodeConfigOverridesGlobalConfig() {
 
-    PlatformLabelerGlobalConfiguration globalConfig =
-        GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
+        PlatformLabelerGlobalConfiguration globalConfig =
+                GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
 
-    LabelConfig globalLabelConfig = new LabelConfig();
+        LabelConfig globalLabelConfig = new LabelConfig();
 
-    globalLabelConfig.setVersion(false);
-    globalLabelConfig.setArchitecture(false);
+        globalLabelConfig.setVersion(false);
+        globalLabelConfig.setArchitecture(false);
 
-    globalConfig.setLabelConfig(globalLabelConfig);
+        globalConfig.setLabelConfig(globalLabelConfig);
 
-    PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
-    LabelConfig labelConfig = new LabelConfig();
-    labelConfig.setVersion(false);
-    nodeProperty.setLabelConfig(labelConfig);
-    r.jenkins.getNodeProperties().add(nodeProperty);
+        PlatformLabelerNodeProperty nodeProperty = new PlatformLabelerNodeProperty();
+        LabelConfig labelConfig = new LabelConfig();
+        labelConfig.setVersion(false);
+        nodeProperty.setLabelConfig(labelConfig);
+        r.jenkins.getNodeProperties().add(nodeProperty);
 
-    nodeLabelCache.onConfigurationChange();
+        nodeLabelCache.onConfigurationChange();
 
-    Collection<LabelAtom> expected = new HashSet<>();
-    expected.add(r.jenkins.getLabelAtom("master"));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureName()));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
+        Collection<LabelAtom> expected = new HashSet<>();
+        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureName()));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitectureNameVersion()));
 
-    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(expected, is(labelsAfter));
-  }
+        Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+        assertThat(expected, is(labelsAfter));
+    }
 
-  @Test
-  public void globalConfigOnlyArchitecture() {
+    @Test
+    public void globalConfigOnlyArchitecture() {
 
-    PlatformLabelerGlobalConfiguration globalConfig =
-        GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
+        PlatformLabelerGlobalConfiguration globalConfig =
+                GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
 
-    LabelConfig globalLabelConfig = new LabelConfig();
+        LabelConfig globalLabelConfig = new LabelConfig();
 
-    globalLabelConfig.setVersion(false);
-    globalLabelConfig.setName(false);
-    globalLabelConfig.setArchitectureName(false);
-    globalLabelConfig.setArchitectureNameVersion(false);
-    globalLabelConfig.setNameVersion(false);
+        globalLabelConfig.setVersion(false);
+        globalLabelConfig.setName(false);
+        globalLabelConfig.setArchitectureName(false);
+        globalLabelConfig.setArchitectureNameVersion(false);
+        globalLabelConfig.setNameVersion(false);
 
-    globalConfig.setLabelConfig(globalLabelConfig);
+        globalConfig.setLabelConfig(globalLabelConfig);
 
-    nodeLabelCache.onConfigurationChange();
+        nodeLabelCache.onConfigurationChange();
 
-    Collection<LabelAtom> expected = new HashSet<>();
-    expected.add(r.jenkins.getLabelAtom("master"));
-    expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
+        Collection<LabelAtom> expected = new HashSet<>();
+        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
 
-    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(expected, is(labelsAfter));
-  }
+        Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+        assertThat(expected, is(labelsAfter));
+    }
 
-  @Test
-  public void configRoundTripTest() throws Exception {
-    PlatformLabelerGlobalConfiguration globalConfig =
-        GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
-    LabelConfig globalLabelConfigBefore = globalConfig.getLabelConfig();
-    r.configRoundtrip();
-    LabelConfig globalLabelConfigAfter = globalConfig.getLabelConfig();
-    assertThat(
-        globalLabelConfigBefore.isArchitecture(), is(globalLabelConfigAfter.isArchitecture()));
-    assertThat(globalLabelConfigBefore.isName(), is(globalLabelConfigAfter.isName()));
-    assertThat(globalLabelConfigBefore.isVersion(), is(globalLabelConfigAfter.isVersion()));
-  }
+    @Test
+    public void configRoundTripTest() throws Exception {
+        PlatformLabelerGlobalConfiguration globalConfig =
+                GlobalConfiguration.all().getInstance(PlatformLabelerGlobalConfiguration.class);
+        LabelConfig globalLabelConfigBefore = globalConfig.getLabelConfig();
+        r.configRoundtrip();
+        LabelConfig globalLabelConfigAfter = globalConfig.getLabelConfig();
+        assertThat(
+                globalLabelConfigBefore.isArchitecture(),
+                is(globalLabelConfigAfter.isArchitecture()));
+        assertThat(globalLabelConfigBefore.isName(), is(globalLabelConfigAfter.isName()));
+        assertThat(globalLabelConfigBefore.isVersion(), is(globalLabelConfigAfter.isVersion()));
+    }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -42,234 +42,235 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  */
 public class NodeLabelCacheTest {
 
-  @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public JenkinsRule r = new JenkinsRule();
 
-  public NodeLabelCacheTest() {
-    /* Intentionally empty constructor */
-  }
-
-  private Computer computer;
-  private Set<LabelAtom> labelsBefore;
-  private NodeLabelCache nodeLabelCache;
-
-  @Before
-  public void setUp() {
-    computer = r.jenkins.toComputer();
-    labelsBefore = computer.getNode().getAssignedLabels();
-    assertThat(labelsBefore, is(not(empty())));
-    nodeLabelCache = new NodeLabelCache();
-  }
-
-  @After
-  public void tearDown() {
-    Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
-    assertThat(labelsBefore, everyItem(in(labelsAfter)));
-  }
-
-  @Test
-  public void testOnOnline() throws Exception {
-    nodeLabelCache.onOnline(computer, TaskListener.NULL);
-  }
-
-  @Test
-  public void testCacheLabels() throws Exception {
-    nodeLabelCache.cacheLabels(computer);
-  }
-
-  @Test
-  public void testRefreshModel() {
-    nodeLabelCache.refreshModel(computer);
-  }
-
-  @Test
-  public void testRefreshModelNullComputer() {
-    nodeLabelCache.refreshModel(null);
-  }
-
-  @Test
-  public void testRefreshModelNullingComputer() {
-    Computer nullingComputer = new NullingComputer(computer.getNode());
-    nodeLabelCache.refreshModel(nullingComputer);
-  }
-
-  @Test(expected = IOException.class)
-  public void testCacheLabelsNullingComputer() throws Exception {
-    Computer nullingComputer = new NullingComputer(computer.getNode());
-    nodeLabelCache.cacheLabels(nullingComputer);
-  }
-
-  @Test
-  public void testGetLabelsForNode_IsNull() throws Exception {
-    Node nullingNode = new NullingNode();
-    Collection<LabelAtom> labels = nodeLabelCache.getLabelsForNode(nullingNode);
-    assertThat(labels, is(empty()));
-  }
-
-  @Test(expected = IOException.class)
-  public void testRequestComputerPlatformDetails_ChannelThrows() throws Exception {
-    Computer throwingComputer = new NullingComputer(computer.getNode(), new IOException());
-    nodeLabelCache.requestComputerPlatformDetails(throwingComputer);
-  }
-
-  /** Class that intentionally returns nulls for test purposes. */
-  private class NullingComputer extends Computer {
-
-    private final IOException exceptionToThrow;
-
-    public NullingComputer(Node node) {
-      super(node);
-      exceptionToThrow = null;
+    public NodeLabelCacheTest() {
+        /* Intentionally empty constructor */
     }
 
-    public NullingComputer(Node node, IOException throwThisException) {
-      super(node);
-      exceptionToThrow = throwThisException;
+    private Computer computer;
+    private Set<LabelAtom> labelsBefore;
+    private NodeLabelCache nodeLabelCache;
+
+    @Before
+    public void setUp() {
+        computer = r.jenkins.toComputer();
+        labelsBefore = computer.getNode().getAssignedLabels();
+        assertThat(labelsBefore, is(not(empty())));
+        nodeLabelCache = new NodeLabelCache();
     }
 
-    @Override
-    public Node getNode() {
-      /* Intentionally return null to test null node handling */
-      return null;
+    @After
+    public void tearDown() {
+        Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
+        assertThat(labelsBefore, everyItem(in(labelsAfter)));
     }
 
-    @Override
-    public VirtualChannel getChannel() {
-      if (exceptionToThrow != null) {
-        return new ThrowingChannel(exceptionToThrow);
-      }
-      /* Intentionally return null to test null channel handling */
-      return null;
+    @Test
+    public void testOnOnline() throws Exception {
+        nodeLabelCache.onOnline(computer, TaskListener.NULL);
     }
 
-    @Override
-    public Charset getDefaultCharset() {
-      throw new UnsupportedOperationException("Unsupported");
+    @Test
+    public void testCacheLabels() throws Exception {
+        nodeLabelCache.cacheLabels(computer);
     }
 
-    @Override
-    public List<LogRecord> getLogRecords() throws IOException, InterruptedException {
-      throw new UnsupportedOperationException("Unsupported");
+    @Test
+    public void testRefreshModel() {
+        nodeLabelCache.refreshModel(computer);
     }
 
-    @Override
-    @RequirePOST
-    public void doLaunchSlaveAgent(StaplerRequest sr, StaplerResponse sr1)
-        throws IOException, ServletException {
-      throw new UnsupportedOperationException("Unsupported");
+    @Test
+    public void testRefreshModelNullComputer() {
+        nodeLabelCache.refreshModel(null);
     }
 
-    @Override
-    protected Future<?> _connect(boolean bln) {
-      throw new UnsupportedOperationException("Unsupported");
+    @Test
+    public void testRefreshModelNullingComputer() {
+        Computer nullingComputer = new NullingComputer(computer.getNode());
+        nodeLabelCache.refreshModel(nullingComputer);
     }
 
-    @Override
-    public Boolean isUnix() {
-      throw new UnsupportedOperationException("Unsupported");
+    @Test(expected = IOException.class)
+    public void testCacheLabelsNullingComputer() throws Exception {
+        Computer nullingComputer = new NullingComputer(computer.getNode());
+        nodeLabelCache.cacheLabels(nullingComputer);
     }
 
-    @Override
-    public boolean isConnecting() {
-      throw new UnsupportedOperationException("Unsupported");
+    @Test
+    public void testGetLabelsForNode_IsNull() throws Exception {
+        Node nullingNode = new NullingNode();
+        Collection<LabelAtom> labels = nodeLabelCache.getLabelsForNode(nullingNode);
+        assertThat(labels, is(empty()));
     }
 
-    @Override
-    public RetentionStrategy getRetentionStrategy() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
-  }
-
-  private class ThrowingChannel implements VirtualChannel {
-    private final IOException exceptionToThrow;
-
-    public ThrowingChannel(IOException exceptionToThrow) {
-      this.exceptionToThrow = exceptionToThrow;
+    @Test(expected = IOException.class)
+    public void testRequestComputerPlatformDetails_ChannelThrows() throws Exception {
+        Computer throwingComputer = new NullingComputer(computer.getNode(), new IOException());
+        nodeLabelCache.requestComputerPlatformDetails(throwingComputer);
     }
 
-    public <V, T extends Throwable> V call(Callable<V, T> callable) throws IOException {
-      if (exceptionToThrow != null) {
-        throw exceptionToThrow;
-      }
-      return null;
+    /** Class that intentionally returns nulls for test purposes. */
+    private class NullingComputer extends Computer {
+
+        private final IOException exceptionToThrow;
+
+        public NullingComputer(Node node) {
+            super(node);
+            exceptionToThrow = null;
+        }
+
+        public NullingComputer(Node node, IOException throwThisException) {
+            super(node);
+            exceptionToThrow = throwThisException;
+        }
+
+        @Override
+        public Node getNode() {
+            /* Intentionally return null to test null node handling */
+            return null;
+        }
+
+        @Override
+        public VirtualChannel getChannel() {
+            if (exceptionToThrow != null) {
+                return new ThrowingChannel(exceptionToThrow);
+            }
+            /* Intentionally return null to test null channel handling */
+            return null;
+        }
+
+        @Override
+        public Charset getDefaultCharset() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        public List<LogRecord> getLogRecords() throws IOException, InterruptedException {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        @RequirePOST
+        public void doLaunchSlaveAgent(StaplerRequest sr, StaplerResponse sr1)
+                throws IOException, ServletException {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        protected Future<?> _connect(boolean bln) {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        public Boolean isUnix() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        public boolean isConnecting() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        @Override
+        public RetentionStrategy getRetentionStrategy() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
     }
 
-    public <V, T extends Throwable> hudson.remoting.Future<V> callAsync(Callable<V, T> callable) {
-      return null;
+    private class ThrowingChannel implements VirtualChannel {
+        private final IOException exceptionToThrow;
+
+        public ThrowingChannel(IOException exceptionToThrow) {
+            this.exceptionToThrow = exceptionToThrow;
+        }
+
+        public <V, T extends Throwable> V call(Callable<V, T> callable) throws IOException {
+            if (exceptionToThrow != null) {
+                throw exceptionToThrow;
+            }
+            return null;
+        }
+
+        public <V, T extends Throwable> hudson.remoting.Future<V> callAsync(
+                Callable<V, T> callable) {
+            return null;
+        }
+
+        public <T> T export(java.lang.Class<T> type, T instance) {
+            return null;
+        }
+
+        public void join() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        public void join(long timeout) {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        public void syncLocalIO() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
+
+        public void close() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
     }
 
-    public <T> T export(java.lang.Class<T> type, T instance) {
-      return null;
-    }
+    private class NullingNode extends Node {
+        public Callable<ClockDifference, IOException> getClockDifferenceCallable() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public void join() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public NodeDescriptor getDescriptor() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public void join(long timeout) {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public void syncLocalIO() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public FilePath getRootPath() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public void close() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
-  }
+        public FilePath getWorkspaceFor(TopLevelItem item) {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-  private class NullingNode extends Node {
-    public Callable<ClockDifference, IOException> getClockDifferenceCallable() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public String getLabelString() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public NodeDescriptor getDescriptor() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public Computer createComputer() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public Node.Mode getMode() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public FilePath getRootPath() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public int getNumExecutors() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public FilePath getWorkspaceFor(TopLevelItem item) {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public Launcher createLauncher(TaskListener listener) {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public String getLabelString() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        public String getNodeDescription() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public Computer createComputer() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
+        @Deprecated
+        public void setNodeName(String name) {
+            throw new UnsupportedOperationException("Unsupported");
+        }
 
-    public Node.Mode getMode() {
-      throw new UnsupportedOperationException("Unsupported");
+        public String getNodeName() {
+            throw new UnsupportedOperationException("Unsupported");
+        }
     }
-
-    public int getNumExecutors() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
-
-    public Launcher createLauncher(TaskListener listener) {
-      throw new UnsupportedOperationException("Unsupported");
-    }
-
-    public String getNodeDescription() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
-
-    @Deprecated
-    public void setNodeName(String name) {
-      throw new UnsupportedOperationException("Unsupported");
-    }
-
-    public String getNodeName() {
-      throw new UnsupportedOperationException("Unsupported");
-    }
-  }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsCheckRolesTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsCheckRolesTest.java
@@ -17,42 +17,43 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 public class PlatformDetailsCheckRolesTest {
 
-  @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public JenkinsRule r = new JenkinsRule();
 
-  private PlatformDetailsTask platformDetailsTask;
+    private PlatformDetailsTask platformDetailsTask;
 
-  @Before
-  public void createPlatformDetailsTask() {
-    platformDetailsTask = new PlatformDetailsTask();
-  }
+    @Before
+    public void createPlatformDetailsTask() {
+        platformDetailsTask = new PlatformDetailsTask();
+    }
 
-  @Test
-  public void testCheckRoles() {
-    RoleChecker checker =
-        new RoleChecker() {
-          @Override
-          public void check(RoleSensitive rs, Collection<Role> roleCollection)
-              throws SecurityException {
-            if (!roleCollection.contains(Roles.SLAVE)) {
-              throw new SecurityException(Roles.SLAVE + " missing");
-            }
-          }
-        };
-    platformDetailsTask.checkRoles(checker);
-  }
+    @Test
+    public void testCheckRoles() {
+        RoleChecker checker =
+                new RoleChecker() {
+                    @Override
+                    public void check(RoleSensitive rs, Collection<Role> roleCollection)
+                            throws SecurityException {
+                        if (!roleCollection.contains(Roles.SLAVE)) {
+                            throw new SecurityException(Roles.SLAVE + " missing");
+                        }
+                    }
+                };
+        platformDetailsTask.checkRoles(checker);
+    }
 
-  @Test(expected = SecurityException.class)
-  public void testCheckRolesThrowsSecurityException() {
-    RoleChecker exceptionThrowingChecker =
-        new RoleChecker() {
-          @Override
-          public void check(RoleSensitive rs, Collection<Role> roleCollection)
-              throws SecurityException {
-            if (roleCollection.contains(Roles.SLAVE)) {
-              throw new SecurityException(Roles.SLAVE + " found, throwing intentional exception");
-            }
-          }
-        };
-    platformDetailsTask.checkRoles(exceptionThrowingChecker);
-  }
+    @Test(expected = SecurityException.class)
+    public void testCheckRolesThrowsSecurityException() {
+        RoleChecker exceptionThrowingChecker =
+                new RoleChecker() {
+                    @Override
+                    public void check(RoleSensitive rs, Collection<Role> roleCollection)
+                            throws SecurityException {
+                        if (roleCollection.contains(Roles.SLAVE)) {
+                            throw new SecurityException(
+                                    Roles.SLAVE + " found, throwing intentional exception");
+                        }
+                    }
+                };
+        platformDetailsTask.checkRoles(exceptionThrowingChecker);
+    }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -20,104 +20,107 @@ import org.reflections.scanners.ResourcesScanner;
 
 public class PlatformDetailsTaskLsbReleaseTest {
 
-  /**
-   * Generate test parameters for Linux lsb_release-a sample files stored as resources.
-   *
-   * @return parameter values to be tested
-   */
-  public static Stream<Object[]> generateReleaseFileNames() {
-    String packageName = PlatformDetailsTaskLsbReleaseTest.class.getPackage().getName();
-    Reflections reflections = new Reflections(packageName, new ResourcesScanner());
-    Set<String> fileNames = reflections.getResources(Pattern.compile(".*lsb_release-a"));
-    Collection<Object[]> data = new ArrayList<>(fileNames.size());
-    for (String fileName : fileNames) {
-      String oneExpectedName = computeExpectedName(fileName);
-      String oneExpectedVersion = computeExpectedVersion(fileName);
-      String oneExpectedArch = "amd64";
-      String trimmedName = fileName.split(".platformlabeler.")[1];
-      Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
-      data.add(oneTest);
+    /**
+     * Generate test parameters for Linux lsb_release-a sample files stored as resources.
+     *
+     * @return parameter values to be tested
+     */
+    public static Stream<Object[]> generateReleaseFileNames() {
+        String packageName = PlatformDetailsTaskLsbReleaseTest.class.getPackage().getName();
+        Reflections reflections = new Reflections(packageName, new ResourcesScanner());
+        Set<String> fileNames = reflections.getResources(Pattern.compile(".*lsb_release-a"));
+        Collection<Object[]> data = new ArrayList<>(fileNames.size());
+        for (String fileName : fileNames) {
+            String oneExpectedName = computeExpectedName(fileName);
+            String oneExpectedVersion = computeExpectedVersion(fileName);
+            String oneExpectedArch = "amd64";
+            String trimmedName = fileName.split(".platformlabeler.")[1];
+            Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
+            data.add(oneTest);
+        }
+        return data.stream();
     }
-    return data.stream();
-  }
 
-  @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
-  @MethodSource("generateReleaseFileNames")
-  @DisplayName("Compute os-release labels")
-  void testComputeLabelsForOsRelease(
-      String lsbReleaseFileName, String expectedName, String expectedVersion, String expectedArch)
-      throws Exception {
-    PlatformDetailsTask details = new PlatformDetailsTask();
-    URL resource = getClass().getResource(lsbReleaseFileName);
-    File lsbReleaseFile = new File(resource.toURI());
-    assertThat(lsbReleaseFile, is(anExistingFile()));
-    LsbRelease release = new LsbRelease(lsbReleaseFile);
-    File suseReleaseFile = new File(lsbReleaseFile.getParentFile(), "SuSE-release");
-    if (suseReleaseFile.isFile()) {
-      details.setSuseRelease(suseReleaseFile);
+    @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
+    @MethodSource("generateReleaseFileNames")
+    @DisplayName("Compute os-release labels")
+    void testComputeLabelsForOsRelease(
+            String lsbReleaseFileName,
+            String expectedName,
+            String expectedVersion,
+            String expectedArch)
+            throws Exception {
+        PlatformDetailsTask details = new PlatformDetailsTask();
+        URL resource = getClass().getResource(lsbReleaseFileName);
+        File lsbReleaseFile = new File(resource.toURI());
+        assertThat(lsbReleaseFile, is(anExistingFile()));
+        LsbRelease release = new LsbRelease(lsbReleaseFile);
+        File suseReleaseFile = new File(lsbReleaseFile.getParentFile(), "SuSE-release");
+        if (suseReleaseFile.isFile()) {
+            details.setSuseRelease(suseReleaseFile);
+        }
+        PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
+        assertThat(result.getArchitecture(), is(expectedArch));
+        assertThat(result.getName(), is(expectedName));
+        assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
+        assertThat(
+                result.getArchitectureNameVersion(),
+                is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+        assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
     }
-    PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
-    assertThat(result.getArchitecture(), is(expectedArch));
-    assertThat(result.getName(), is(expectedName));
-    assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
-    assertThat(
-        result.getArchitectureNameVersion(),
-        is(expectedArch + "-" + expectedName + "-" + expectedVersion));
-    assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
-  }
 
-  private static String computeExpectedName(String filename) {
-    if (filename.contains("amzn")) {
-      if (filename.contains("amzn/2018.03")) {
-        return "AmazonAMI";
-      }
-      return "Amazon";
+    private static String computeExpectedName(String filename) {
+        if (filename.contains("amzn")) {
+            if (filename.contains("amzn/2018.03")) {
+                return "AmazonAMI";
+            }
+            return "Amazon";
+        }
+        if (filename.contains("alpine")) {
+            return "Alpine";
+        }
+        if (filename.contains("centos")) {
+            return "CentOS";
+        }
+        if (filename.contains("debian")) {
+            return "Debian";
+        }
+        if (filename.contains("fedora")) {
+            return "Fedora";
+        }
+        if (filename.contains("oraclelinux")) {
+            return "OracleServer";
+        }
+        if (filename.contains("linuxmint")) {
+            return "LinuxMint";
+        }
+        if (filename.contains("raspbian")) {
+            return "Raspbian";
+        }
+        if (filename.contains("rhel") || filename.contains("ubi")) {
+            return "RedHatEnterprise";
+        }
+        if (filename.contains("ubuntu")) {
+            return "Ubuntu";
+        }
+        if (filename.contains("scientific")) {
+            return "Scientific";
+        }
+        if (filename.contains("sles")) {
+            return "SUSE";
+        }
+        if (filename.contains("opensuse-leap")) {
+            return "openSUSE";
+        }
+        if (filename.contains("opensuse-tumbleweed")) {
+            return "openSUSE";
+        }
+        return filename.toLowerCase(Locale.ENGLISH);
     }
-    if (filename.contains("alpine")) {
-      return "Alpine";
-    }
-    if (filename.contains("centos")) {
-      return "CentOS";
-    }
-    if (filename.contains("debian")) {
-      return "Debian";
-    }
-    if (filename.contains("fedora")) {
-      return "Fedora";
-    }
-    if (filename.contains("oraclelinux")) {
-      return "OracleServer";
-    }
-    if (filename.contains("linuxmint")) {
-      return "LinuxMint";
-    }
-    if (filename.contains("raspbian")) {
-      return "Raspbian";
-    }
-    if (filename.contains("rhel") || filename.contains("ubi")) {
-      return "RedHatEnterprise";
-    }
-    if (filename.contains("ubuntu")) {
-      return "Ubuntu";
-    }
-    if (filename.contains("scientific")) {
-      return "Scientific";
-    }
-    if (filename.contains("sles")) {
-      return "SUSE";
-    }
-    if (filename.contains("opensuse-leap")) {
-      return "openSUSE";
-    }
-    if (filename.contains("opensuse-tumbleweed")) {
-      return "openSUSE";
-    }
-    return filename.toLowerCase(Locale.ENGLISH);
-  }
 
-  private static String computeExpectedVersion(String filename) {
-    File file = new File(filename);
-    File parentDir = file.getParentFile();
-    return parentDir.getName();
-  }
+    private static String computeExpectedVersion(String filename) {
+        File file = new File(filename);
+        File parentDir = file.getParentFile();
+        return parentDir.getName();
+    }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -20,130 +20,133 @@ import org.reflections.scanners.ResourcesScanner;
 
 public class PlatformDetailsTaskReleaseTest {
 
-  /**
-   * Generate test parameters for Linux os-release, redhat-release and SuSE-release sample files
-   * stored as resources.
-   *
-   * @return parameter values to be tested
-   */
-  public static Stream<Object[]> generateReleaseFileNames() {
-    String packageName = PlatformDetailsTaskReleaseTest.class.getPackage().getName();
-    Reflections reflections = new Reflections(packageName, new ResourcesScanner());
-    Set<String> fileNames = reflections.getResources(Pattern.compile(".*-release"));
-    Collection<Object[]> data = new ArrayList<>(fileNames.size());
-    for (String fileName : fileNames) {
-      String oneExpectedName = computeExpectedName(fileName);
-      String oneExpectedVersion = computeExpectedVersion(fileName);
-      String oneExpectedArch = "amd64";
-      String trimmedName = fileName.split(".platformlabeler.")[1];
-      Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
-      data.add(oneTest);
+    /**
+     * Generate test parameters for Linux os-release, redhat-release and SuSE-release sample files
+     * stored as resources.
+     *
+     * @return parameter values to be tested
+     */
+    public static Stream<Object[]> generateReleaseFileNames() {
+        String packageName = PlatformDetailsTaskReleaseTest.class.getPackage().getName();
+        Reflections reflections = new Reflections(packageName, new ResourcesScanner());
+        Set<String> fileNames = reflections.getResources(Pattern.compile(".*-release"));
+        Collection<Object[]> data = new ArrayList<>(fileNames.size());
+        for (String fileName : fileNames) {
+            String oneExpectedName = computeExpectedName(fileName);
+            String oneExpectedVersion = computeExpectedVersion(fileName);
+            String oneExpectedArch = "amd64";
+            String trimmedName = fileName.split(".platformlabeler.")[1];
+            Object[] oneTest = {trimmedName, oneExpectedName, oneExpectedVersion, oneExpectedArch};
+            data.add(oneTest);
+        }
+        return data.stream();
     }
-    return data.stream();
-  }
 
-  @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
-  @MethodSource("generateReleaseFileNames")
-  @DisplayName("Compute platform details from release file")
-  void testComputeLabelsForRelease(
-      String releaseFileName, String expectedName, String expectedVersion, String expectedArch)
-      throws Exception {
-    PlatformDetailsTask details = new PlatformDetailsTask();
-    URL resource = getClass().getResource(releaseFileName);
-    File releaseFile = new File(resource.toURI());
-    assertThat(releaseFile, is(anExistingFile()));
-    if (releaseFile.getName().startsWith("redhat")) {
-      /* Replaces os-release with Red Hat additional file */
-      details.setOsReleaseFile(null);
-      details.setDebianVersion(null);
-      details.setRedhatRelease(releaseFile);
-      details.setSuseRelease(null);
-    } else if (releaseFile.getName().startsWith("SuSE")) {
-      /* Replaces os-release with SuSE additional file */
-      details.setOsReleaseFile(null);
-      details.setDebianVersion(null);
-      details.setSuseRelease(releaseFile);
-      details.setRedhatRelease(null);
-    } else if (releaseFileName.startsWith("debian")) {
-      /* Adds another file to consider in addition to os-release */
-      details.setOsReleaseFile(releaseFile);
-      details.setSuseRelease(null);
-      details.setRedhatRelease(null);
-      /* Extra file needed for Debian testing and unstable. No version in os-release */
-      File debianVersionFile = new File(releaseFile.getParentFile(), "debian_version");
-      details.setDebianVersion(debianVersionFile.exists() ? debianVersionFile : null);
-    } else {
-      details.setOsReleaseFile(releaseFile);
-      details.setRedhatRelease(null);
-      details.setSuseRelease(null);
+    @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
+    @MethodSource("generateReleaseFileNames")
+    @DisplayName("Compute platform details from release file")
+    void testComputeLabelsForRelease(
+            String releaseFileName,
+            String expectedName,
+            String expectedVersion,
+            String expectedArch)
+            throws Exception {
+        PlatformDetailsTask details = new PlatformDetailsTask();
+        URL resource = getClass().getResource(releaseFileName);
+        File releaseFile = new File(resource.toURI());
+        assertThat(releaseFile, is(anExistingFile()));
+        if (releaseFile.getName().startsWith("redhat")) {
+            /* Replaces os-release with Red Hat additional file */
+            details.setOsReleaseFile(null);
+            details.setDebianVersion(null);
+            details.setRedhatRelease(releaseFile);
+            details.setSuseRelease(null);
+        } else if (releaseFile.getName().startsWith("SuSE")) {
+            /* Replaces os-release with SuSE additional file */
+            details.setOsReleaseFile(null);
+            details.setDebianVersion(null);
+            details.setSuseRelease(releaseFile);
+            details.setRedhatRelease(null);
+        } else if (releaseFileName.startsWith("debian")) {
+            /* Adds another file to consider in addition to os-release */
+            details.setOsReleaseFile(releaseFile);
+            details.setSuseRelease(null);
+            details.setRedhatRelease(null);
+            /* Extra file needed for Debian testing and unstable. No version in os-release */
+            File debianVersionFile = new File(releaseFile.getParentFile(), "debian_version");
+            details.setDebianVersion(debianVersionFile.exists() ? debianVersionFile : null);
+        } else {
+            details.setOsReleaseFile(releaseFile);
+            details.setRedhatRelease(null);
+            details.setSuseRelease(null);
+        }
+        String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
+        LsbRelease release = new LsbRelease(unknown, unknown);
+        PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
+        assertThat(result.getName(), is(expectedName));
+        assertThat(result.getArchitecture(), is(expectedArch));
+        assertThat(result.getVersion(), is(expectedVersion));
+        assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
+        assertThat(
+                result.getArchitectureNameVersion(),
+                is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+        assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
     }
-    String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
-    LsbRelease release = new LsbRelease(unknown, unknown);
-    PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
-    assertThat(result.getName(), is(expectedName));
-    assertThat(result.getArchitecture(), is(expectedArch));
-    assertThat(result.getVersion(), is(expectedVersion));
-    assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
-    assertThat(
-        result.getArchitectureNameVersion(),
-        is(expectedArch + "-" + expectedName + "-" + expectedVersion));
-    assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
-  }
 
-  private static String computeExpectedName(String filename) {
-    if (filename.contains("amzn")) {
-      return "Amazon";
+    private static String computeExpectedName(String filename) {
+        if (filename.contains("amzn")) {
+            return "Amazon";
+        }
+        if (filename.contains("alpine")) {
+            return "Alpine";
+        }
+        if (filename.contains("centos")) {
+            return "CentOS";
+        }
+        if (filename.contains("clearlinux")) {
+            return "clear-linux-os";
+        }
+        if (filename.contains("debian")) {
+            return "Debian";
+        }
+        if (filename.contains("fedora")) {
+            return "Fedora";
+        }
+        if (filename.contains("linuxmint")) {
+            return "LinuxMint";
+        }
+        if (filename.contains("opensuse")) {
+            return "openSUSE";
+        }
+        if (filename.contains("oraclelinux")) {
+            return "OracleServer";
+        }
+        if (filename.contains("raspbian")) {
+            return "Raspbian";
+        }
+        if (filename.contains("rhel") || filename.contains("ubi")) {
+            return "RedHatEnterprise";
+        }
+        if (filename.contains("ubuntu")) {
+            return "Ubuntu";
+        }
+        if (filename.contains("scientific")) {
+            return "Scientific";
+        }
+        if (filename.contains("sles")) {
+            return "SUSE";
+        }
+        return filename.toLowerCase(Locale.ENGLISH);
     }
-    if (filename.contains("alpine")) {
-      return "Alpine";
-    }
-    if (filename.contains("centos")) {
-      return "CentOS";
-    }
-    if (filename.contains("clearlinux")) {
-      return "clear-linux-os";
-    }
-    if (filename.contains("debian")) {
-      return "Debian";
-    }
-    if (filename.contains("fedora")) {
-      return "Fedora";
-    }
-    if (filename.contains("linuxmint")) {
-      return "LinuxMint";
-    }
-    if (filename.contains("opensuse")) {
-      return "openSUSE";
-    }
-    if (filename.contains("oraclelinux")) {
-      return "OracleServer";
-    }
-    if (filename.contains("raspbian")) {
-      return "Raspbian";
-    }
-    if (filename.contains("rhel") || filename.contains("ubi")) {
-      return "RedHatEnterprise";
-    }
-    if (filename.contains("ubuntu")) {
-      return "Ubuntu";
-    }
-    if (filename.contains("scientific")) {
-      return "Scientific";
-    }
-    if (filename.contains("sles")) {
-      return "SUSE";
-    }
-    return filename.toLowerCase(Locale.ENGLISH);
-  }
 
-  private static String computeExpectedVersion(String filename) {
-    File file = new File(filename);
-    File parentDir = file.getParentFile();
-    if (parentDir.getName().equals("testing") || parentDir.getName().equals("unstable")) {
-      /* Debian unstable and Debian testing are indistinguishable by package definition */
-      /* See https://unix.stackexchange.com/questions/464812/ for more details */
-      return "bullseye";
+    private static String computeExpectedVersion(String filename) {
+        File file = new File(filename);
+        File parentDir = file.getParentFile();
+        if (parentDir.getName().equals("testing") || parentDir.getName().equals("unstable")) {
+            /* Debian unstable and Debian testing are indistinguishable by package definition */
+            /* See https://unix.stackexchange.com/questions/464812/ for more details */
+            return "bullseye";
+        }
+        return parentDir.getName();
     }
-    return parentDir.getName();
-  }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -19,155 +19,161 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class PlatformDetailsTaskStaticStringTest {
 
-  /**
-   * Generate test parameters for cases which can be tested with static string conversions. Linux
-   * platform labeling can't be tested with static string conversions. Refer to other tests for
-   * Linux platform labeling tests.
-   *
-   * @return parameter values to be tested
-   */
-  public static Stream<Object[]> generateTestParameters() {
-    Collection<Object[]> data =
-        Arrays.asList(
-            new Object[][] {
-              /** General cases for operating system names in platformlabeler-1.1 */
-              {"mac", "amd64", "11.0"}, // macOS
-              {"Solaris", "amd64", "11.3"}, // Solaris
-              {"Solaris", "sparc", "11.3"}, // Solaris
-              {"SunOS", "sparc", "4.1.4"}, // SunOS
-              /** Special Windows version cases using version names in platformlabeler-1.1 */
-              {"Windows 2000", "amd64", "5.0"}, // Win2000
-              {"Windows 2000", "x86", "5.0"}, // Win2000
-              {"Windows 2003", "amd64", "5.2"}, // Win2003
-              {"Windows 2003", "x86", "5.2"}, // Win2003
-              {"Windows NT", "amd64", "4.0"}, // WinNT
-              {"Windows NT", "x86", "4.0"}, // WinNT
-              {"Windows XP", "amd64", "5.1"}, // WinXP
-              {"Windows XP", "x86", "5.1"}, // WinXP
-              /** General Windows version cases using version numbers in platformlabeler-1.1 */
-              {"Windows 10", "amd64", "10.0"}, // Win10
-              {"Windows 10", "x86", "10.0"}, // Win10
-              {"Windows 2008R2", "amd64", "6.1"}, // Win2008R2
-              {"Windows 7", "amd64", "6.1"}, // Win7
-              {"Windows 7", "x86", "6.1"}, // Win7
-              {"Windows Server 2012 R2", "amd64", "6.3"}, // Win2012R2
-              {"Windows Vista64", "amd64", "6.0.6001"}, // WinVista
-              {"Windows Vista", "amd64", "6.0.6000"}, // WinVista
-              {"Windows Vista", "x86", "6.0.6000"}, // WinVista
-              /** General case for operating systems unknown to platformlabeler-1.1 */
-              {"FreeBSD", "amd64", "10.3-STABLE"}, // FreeBSD
-            });
+    /**
+     * Generate test parameters for cases which can be tested with static string conversions. Linux
+     * platform labeling can't be tested with static string conversions. Refer to other tests for
+     * Linux platform labeling tests.
+     *
+     * @return parameter values to be tested
+     */
+    public static Stream<Object[]> generateTestParameters() {
+        Collection<Object[]> data =
+                Arrays.asList(
+                        new Object[][] {
+                            /** General cases for operating system names in platformlabeler-1.1 */
+                            {"mac", "amd64", "11.0"}, // macOS
+                            {"Solaris", "amd64", "11.3"}, // Solaris
+                            {"Solaris", "sparc", "11.3"}, // Solaris
+                            {"SunOS", "sparc", "4.1.4"}, // SunOS
+                            /**
+                             * Special Windows version cases using version names in
+                             * platformlabeler-1.1
+                             */
+                            {"Windows 2000", "amd64", "5.0"}, // Win2000
+                            {"Windows 2000", "x86", "5.0"}, // Win2000
+                            {"Windows 2003", "amd64", "5.2"}, // Win2003
+                            {"Windows 2003", "x86", "5.2"}, // Win2003
+                            {"Windows NT", "amd64", "4.0"}, // WinNT
+                            {"Windows NT", "x86", "4.0"}, // WinNT
+                            {"Windows XP", "amd64", "5.1"}, // WinXP
+                            {"Windows XP", "x86", "5.1"}, // WinXP
+                            /**
+                             * General Windows version cases using version numbers in
+                             * platformlabeler-1.1
+                             */
+                            {"Windows 10", "amd64", "10.0"}, // Win10
+                            {"Windows 10", "x86", "10.0"}, // Win10
+                            {"Windows 2008R2", "amd64", "6.1"}, // Win2008R2
+                            {"Windows 7", "amd64", "6.1"}, // Win7
+                            {"Windows 7", "x86", "6.1"}, // Win7
+                            {"Windows Server 2012 R2", "amd64", "6.3"}, // Win2012R2
+                            {"Windows Vista64", "amd64", "6.0.6001"}, // WinVista
+                            {"Windows Vista", "amd64", "6.0.6000"}, // WinVista
+                            {"Windows Vista", "x86", "6.0.6000"}, // WinVista
+                            /** General case for operating systems unknown to platformlabeler-1.1 */
+                            {"FreeBSD", "amd64", "10.3-STABLE"}, // FreeBSD
+                        });
 
-    /* Don't add data for this platform if linux - linux decodes the distribution as a label */
-    String myName = System.getProperty("os.name");
-    if (myName.equalsIgnoreCase("linux")) {
-      return data.stream();
-    }
-
-    /* Check this platform is in the test data */
-    String myArch = System.getProperty("os.arch");
-    String myVersion = System.getProperty("os.version");
-    for (Object[] testData : data) {
-      if (testData[0].equals(myName)
-          && testData[1].equals(myArch)
-          && testData[2].equals(myVersion)) {
-        return data.stream();
-      }
-    }
-
-    /* Add data for this platform, it is not already in the data and is not linux */
-    Object[] myTestData = {myName, myArch, myVersion};
-    List<Object[]> augmentedData = new ArrayList<>();
-    augmentedData.add(myTestData);
-    augmentedData.addAll(data);
-    return augmentedData.stream();
-  }
-
-  @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
-  @MethodSource("generateTestParameters")
-  @DisplayName("Compute labels from static strings")
-  void testComputeLabels(String name, String arch, String version) throws Exception {
-    String expectedName = computeExpectedName(name);
-    String expectedArch = computeExpectedArch(name, arch);
-    String expectedVersion = computeVersion(name, version);
-    PlatformDetailsTask details = new PlatformDetailsTask();
-    PlatformDetails result = details.computeLabels(arch, name, version);
-    assertThat(result.getArchitecture(), is(expectedArch));
-    assertThat(result.getName(), is(expectedName));
-    assertThat(result.getVersion(), is(expectedVersion));
-  }
-
-  private static String computeExpectedArch(String name, String arch) {
-    if (!isWindows() || !name.startsWith("Windows")) {
-      return arch;
-    }
-    final String env1 = System.getenv("PROCESSOR_ARCHITECTURE");
-    final String env2 = System.getenv("PROCESSOR_ARCHITEW6432");
-    if ("amd64".equalsIgnoreCase(env1) || "amd64".equalsIgnoreCase(env2)) {
-      arch = "amd64";
-    }
-    return arch;
-  }
-
-  private String computeExpectedName(String name) {
-    if (name.startsWith("Windows")) {
-      return "windows";
-    }
-    // Handle cases like "Mac OS X" in the same way as the validation code
-    if (name.startsWith("Mac")) {
-      return "mac";
-    }
-    return name.toLowerCase(Locale.ENGLISH);
-  }
-
-  private String computeVersion(String name, String version) {
-    if (name.startsWith("Windows")) {
-      switch (version) {
-        case "4.0":
-          version = "nt4";
-          break;
-        case "5.0":
-          version = "2000";
-          break;
-        case "5.1":
-          version = "xp";
-          break;
-        case "5.2":
-          version = "2003";
-          break;
-        default:
-          break;
-      }
-    } else if (name.startsWith("FreeBSD")) {
-      return getFreeBsdVersion(version);
-    }
-    return version;
-  }
-
-  private String getFreeBsdVersion(String version) {
-    /* If no freebsd-version command, return the provided default value */
-    File freebsdVersionCommand = new File("/bin/freebsd-version");
-    if (!freebsdVersionCommand.exists()) {
-      return version;
-    }
-    /* Compute the expected version number value */
-    try {
-      Process p = Runtime.getRuntime().exec("/bin/freebsd-version -u");
-      p.waitFor();
-      try (BufferedReader b =
-          new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
-        String line = b.readLine();
-        if (line != null) {
-          version = line;
+        /* Don't add data for this platform if linux - linux decodes the distribution as a label */
+        String myName = System.getProperty("os.name");
+        if (myName.equalsIgnoreCase("linux")) {
+            return data.stream();
         }
-      }
-    } catch (IOException | InterruptedException e) {
-      /* Return version instead of throwing an exception */
-    }
-    return version;
-  }
 
-  private static boolean isWindows() {
-    return File.pathSeparatorChar == ';';
-  }
+        /* Check this platform is in the test data */
+        String myArch = System.getProperty("os.arch");
+        String myVersion = System.getProperty("os.version");
+        for (Object[] testData : data) {
+            if (testData[0].equals(myName)
+                    && testData[1].equals(myArch)
+                    && testData[2].equals(myVersion)) {
+                return data.stream();
+            }
+        }
+
+        /* Add data for this platform, it is not already in the data and is not linux */
+        Object[] myTestData = {myName, myArch, myVersion};
+        List<Object[]> augmentedData = new ArrayList<>();
+        augmentedData.add(myTestData);
+        augmentedData.addAll(data);
+        return augmentedData.stream();
+    }
+
+    @ParameterizedTest(name = "file: {0}, expected: '{1}', {2}, {3}")
+    @MethodSource("generateTestParameters")
+    @DisplayName("Compute labels from static strings")
+    void testComputeLabels(String name, String arch, String version) throws Exception {
+        String expectedName = computeExpectedName(name);
+        String expectedArch = computeExpectedArch(name, arch);
+        String expectedVersion = computeVersion(name, version);
+        PlatformDetailsTask details = new PlatformDetailsTask();
+        PlatformDetails result = details.computeLabels(arch, name, version);
+        assertThat(result.getArchitecture(), is(expectedArch));
+        assertThat(result.getName(), is(expectedName));
+        assertThat(result.getVersion(), is(expectedVersion));
+    }
+
+    private static String computeExpectedArch(String name, String arch) {
+        if (!isWindows() || !name.startsWith("Windows")) {
+            return arch;
+        }
+        final String env1 = System.getenv("PROCESSOR_ARCHITECTURE");
+        final String env2 = System.getenv("PROCESSOR_ARCHITEW6432");
+        if ("amd64".equalsIgnoreCase(env1) || "amd64".equalsIgnoreCase(env2)) {
+            arch = "amd64";
+        }
+        return arch;
+    }
+
+    private String computeExpectedName(String name) {
+        if (name.startsWith("Windows")) {
+            return "windows";
+        }
+        // Handle cases like "Mac OS X" in the same way as the validation code
+        if (name.startsWith("Mac")) {
+            return "mac";
+        }
+        return name.toLowerCase(Locale.ENGLISH);
+    }
+
+    private String computeVersion(String name, String version) {
+        if (name.startsWith("Windows")) {
+            switch (version) {
+                case "4.0":
+                    version = "nt4";
+                    break;
+                case "5.0":
+                    version = "2000";
+                    break;
+                case "5.1":
+                    version = "xp";
+                    break;
+                case "5.2":
+                    version = "2003";
+                    break;
+                default:
+                    break;
+            }
+        } else if (name.startsWith("FreeBSD")) {
+            return getFreeBsdVersion(version);
+        }
+        return version;
+    }
+
+    private String getFreeBsdVersion(String version) {
+        /* If no freebsd-version command, return the provided default value */
+        File freebsdVersionCommand = new File("/bin/freebsd-version");
+        if (!freebsdVersionCommand.exists()) {
+            return version;
+        }
+        /* Compute the expected version number value */
+        try {
+            Process p = Runtime.getRuntime().exec("/bin/freebsd-version -u");
+            p.waitFor();
+            try (BufferedReader b =
+                    new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
+                String line = b.readLine();
+                if (line != null) {
+                    version = line;
+                }
+            }
+        } catch (IOException | InterruptedException e) {
+            /* Return version instead of throwing an exception */
+        }
+        return version;
+    }
+
+    private static boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -17,288 +17,292 @@ import org.junit.jupiter.api.Test;
 
 public class PlatformDetailsTaskTest {
 
-  private PlatformDetailsTask platformDetailsTask;
+    private PlatformDetailsTask platformDetailsTask;
 
-  private static final String SYSTEM_OS_ARCH =
-      System.getProperty("os.arch", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-  private static final String SYSTEM_OS_NAME =
-      System.getProperty("os.name", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-  /**
-   * SPECIAL_CASE_ARCH is used to test x86 detection when running on 64 bit Intel processors. When
-   * running on non-Intel processors, use the system architecture reported by Java.
-   */
-  private static final String SPECIAL_CASE_ARCH =
-      SYSTEM_OS_ARCH.contains("amd") ? "x86" : SYSTEM_OS_ARCH;
-
-  @BeforeEach
-  void createPlatformDetailsTask() {
-    platformDetailsTask = new PlatformDetailsTask();
-  }
-
-  @Test
-  @DisplayName("test remote call for platform details")
-  void testCall() throws Exception {
-    PlatformDetails details = platformDetailsTask.call();
-    if (isWindows()) {
-      assertThat(details.getName(), is("windows"));
-    } else {
-      assertThat(details.getName(), is(not("windows")));
-    }
-    assertPlatformDetails(details);
-  }
-
-  private void assertPlatformDetails(PlatformDetails details) {
-    String osName = SYSTEM_OS_NAME;
-    assertThat(osName, is(not(PlatformDetailsTask.UNKNOWN_VALUE_STRING)));
-    if (osName.toLowerCase(Locale.ENGLISH).startsWith("linux")) {
-      String name = details.getName();
-      assertThat(name, is(not("windows")));
-      assertThat(name, is(not("linux")));
-      assertThat(name, is(not("Linux")));
-      assertThat(name, is(not(PlatformDetailsTask.UNKNOWN_VALUE_STRING)));
-      assertThat(
-          name,
-          anyOf(
-              is("Alpine"),
-              is("Amazon"),
-              is("AmazonAMI"),
-              is("CentOS"),
-              is("Debian"),
-              is("openSUSE"),
-              is("OracleServer"),
-              is("Raspbian"),
-              is("SUSE"),
-              is("Ubuntu")));
-      // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
-      String expectedArch = SYSTEM_OS_ARCH;
-      if (expectedArch.equals("amd64")) {
-        expectedArch =
-            System.getProperty("sun.arch.data.model", "23").equals("32") ? "x86" : "amd64";
-      }
-      // Assumes tests run in JVM that matches operating system
-      assertThat(details.getArchitecture(), is(expectedArch));
-    }
-  }
-
-  @Test
-  @DisplayName("test 32 bit Linux label computation")
-  void testComputeLabelsCanonicalLinuxArch() throws Exception {
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
-    assertPlatformDetails(details);
-  }
-
-  @Test
-  @DisplayName("test CanonicalLinuxArch stream")
-  void testCanonicalLinuxArchStream() throws IOException {
-    String unameOutput = "x86_64";
-    InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
-    assertThat(
-        platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH), is("amd64"));
-  }
-
-  @Test
-  @DisplayName("test CanonicalLinuxArch stream ARM")
-  void testCanonicalLinuxArchStreamARM() throws IOException {
-    String unameOutput = "aarch64";
-    InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
-    assertThat(
-        platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH),
-        is(unameOutput));
-  }
-
-  @Test
-  @DisplayName("test CanonicalLinuxArch stream empty")
-  void testCanonicalLinuxArchStreamEmpty() throws IOException {
-    String unameOutput = "";
-    String expectedArch = "Expected-Arch";
-    InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
-    assertThat(
-        platformDetailsTask.getCanonicalLinuxArchStream(stream, expectedArch), is(expectedArch));
-  }
-
-  @Test
-  @DisplayName("test Linux label computation without lsb_release")
-  void testComputeLabelsLinuxWithoutLsbRelease() throws Exception {
-    if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
-      return;
-    }
-    String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
-    LsbRelease release = new LsbRelease(unknown, unknown);
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
-    assertPlatformDetails(details);
-  }
-
-  @Test
-  @DisplayName("test Linux label computation with null lsb_release")
-  void testComputeLabelsLinuxWithNullLsbRelease() throws Exception {
-    if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
-      return;
-    }
-    LsbRelease release = null;
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
-    assertPlatformDetails(details);
-  }
-
-  @Test
-  @DisplayName("test Windows 32 bit empty second and third arguments")
-  void testCheckWindows32BitEmptyArgs() {
-    /* Always testing this case, no SPECIAL_CASE_ARCH needed */
-    assertThat(platformDetailsTask.checkWindows32Bit("x86", "", ""), is("x86"));
-  }
-
-  @Test
-  @DisplayName("test Windows 32 bit arbitrary arch")
-  void testCheckWindows32BitArbitraryArch() {
-    /* Always testing this case, no SPECIAL_CASE_ARCH needed */
-    assertThat(platformDetailsTask.checkWindows32Bit("not-x86", "", ""), is("not-x86"));
-  }
-
-  @Test
-  @DisplayName("test Windows 32 bit")
-  void testCheckWindows32Bit() {
-    /* Always testing this case, no SPECIAL_CASE_ARCH needed */
-    assertThat(platformDetailsTask.checkWindows32Bit("x86", "AMD64", ""), is("amd64"));
-  }
-
-  @Test
-  @DisplayName("test Windows 32 bit with amd64")
-  void testCheckWindows32BitAMD64SecondArgument() {
-    /* Always testing this case, no SPECIAL_CASE_ARCH needed */
-    assertThat(platformDetailsTask.checkWindows32Bit("x86", "x86", "AMD64"), is("amd64"));
-  }
-
-  @Test
-  @DisplayName("test operating system name")
-  void compareOSName() throws Exception {
-    if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
-      return;
-    }
-    String computedName =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy").getName();
-    String readName = platformDetailsTask.getReleaseIdentifier("ID");
-    assertThat(computedName, is(readName));
-  }
-
-  @Test
-  @DisplayName("test release identifier on missing file")
-  void getReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
-    platformDetailsTask.setOsReleaseFile(new File("/this/file/does/not/exist"));
-    String name = platformDetailsTask.getReleaseIdentifier("ID");
-    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read Debian version identifier missing file")
-  void getDebianVersionIdentifierMissingFileReturnsUnknownValue() throws Exception {
-    platformDetailsTask.setDebianVersion(new File("/this/file/does/not/exist"));
-    String version = platformDetailsTask.getDebianVersionIdentifier();
-    assertThat(version, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read Debian version identifier null file")
-  void getDebianVersionNullFileReturnsUnknownValue() throws Exception {
-    platformDetailsTask.setDebianVersion(null);
-    String version = platformDetailsTask.getDebianVersionIdentifier();
-    assertThat(version, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read Red Hat release identifier")
-  void getRedhatReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
-    platformDetailsTask.setRedhatRelease(new File("/this/file/does/not/exist"));
-    String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
-    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read Red Hat release identifier null file")
-  void getRedhatReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
-    platformDetailsTask.setRedhatRelease(null);
-    String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
-    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read Red Hat release identifier wrong file")
-  void getRedhatReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
-    platformDetailsTask.setRedhatRelease(new File("/etc/hosts")); // Not redhat-release file
-    String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
-    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read SUSE release identifier missing file")
-  void getSuseReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
-    platformDetailsTask.setSuseRelease(new File("/this/file/does/not/exist"));
-    String name = platformDetailsTask.getSuseReleaseIdentifier("ID");
-    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read SUSE release identifier null file")
-  void getSuseReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
-    platformDetailsTask.setSuseRelease(null);
-    String name = platformDetailsTask.getSuseReleaseIdentifier("ID");
-    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Read SUSE release identifier wrong file")
-  void getSuseReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
-    if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
-      return;
-    }
-    platformDetailsTask.setSuseRelease(new File("/etc/hosts")); // Not SuSE-release file
-    String name = platformDetailsTask.getSuseReleaseIdentifier("ID");
-    assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
-  }
-
-  @Test
-  @DisplayName("Compare operating system version")
-  void compareOSVersion() throws Exception {
-    if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
-      return;
-    }
-    PlatformDetails details =
-        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
-    String version = platformDetailsTask.getReleaseIdentifier("VERSION_ID");
-    /* Check that the version string returned by getReleaseIdentifier
-     * is at least at the beginning of one of the detail values. Allow
-     * Debian 8, 9, and 10 and CentOS 7 to report their base version
-     * in the /etc/os-release file without reporting their incremental
-     * version
+    private static final String SYSTEM_OS_ARCH =
+            System.getProperty("os.arch", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+    private static final String SYSTEM_OS_NAME =
+            System.getProperty("os.name", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+    /**
+     * SPECIAL_CASE_ARCH is used to test x86 detection when running on 64 bit Intel processors. When
+     * running on non-Intel processors, use the system architecture reported by Java.
      */
-    String foundValue = version;
-    if (details.getVersion().startsWith(version)) {
-      foundValue = details.getVersion();
-    }
-    /* If VERSION_ID has the unknown value then handle it as a special
-     * case.  Debian testing does not include a VERSION_ID value in
-     * the /etc/os-release file.  If there is no value for VERSION_ID,
-     * then confirm that the details are for Debian testing and skip
-     * the VERSION_ID assertion.
-     */
-    if (version.startsWith("unknown")) {
-      assertThat(details.getName(), is("Debian"));
-      assertThat(details.getVersion(), is("testing"));
-    } else {
-      assertThat(details.getVersion(), anyOf(is(version), is(foundValue)));
-    }
-  }
+    private static final String SPECIAL_CASE_ARCH =
+            SYSTEM_OS_ARCH.contains("amd") ? "x86" : SYSTEM_OS_ARCH;
 
-  private boolean isWindows() {
-    return File.pathSeparatorChar == ';';
-  }
+    @BeforeEach
+    void createPlatformDetailsTask() {
+        platformDetailsTask = new PlatformDetailsTask();
+    }
+
+    @Test
+    @DisplayName("test remote call for platform details")
+    void testCall() throws Exception {
+        PlatformDetails details = platformDetailsTask.call();
+        if (isWindows()) {
+            assertThat(details.getName(), is("windows"));
+        } else {
+            assertThat(details.getName(), is(not("windows")));
+        }
+        assertPlatformDetails(details);
+    }
+
+    private void assertPlatformDetails(PlatformDetails details) {
+        String osName = SYSTEM_OS_NAME;
+        assertThat(osName, is(not(PlatformDetailsTask.UNKNOWN_VALUE_STRING)));
+        if (osName.toLowerCase(Locale.ENGLISH).startsWith("linux")) {
+            String name = details.getName();
+            assertThat(name, is(not("windows")));
+            assertThat(name, is(not("linux")));
+            assertThat(name, is(not("Linux")));
+            assertThat(name, is(not(PlatformDetailsTask.UNKNOWN_VALUE_STRING)));
+            assertThat(
+                    name,
+                    anyOf(
+                            is("Alpine"),
+                            is("Amazon"),
+                            is("AmazonAMI"),
+                            is("CentOS"),
+                            is("Debian"),
+                            is("openSUSE"),
+                            is("OracleServer"),
+                            is("Raspbian"),
+                            is("SUSE"),
+                            is("Ubuntu")));
+            // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
+            String expectedArch = SYSTEM_OS_ARCH;
+            if (expectedArch.equals("amd64")) {
+                expectedArch =
+                        System.getProperty("sun.arch.data.model", "23").equals("32")
+                                ? "x86"
+                                : "amd64";
+            }
+            // Assumes tests run in JVM that matches operating system
+            assertThat(details.getArchitecture(), is(expectedArch));
+        }
+    }
+
+    @Test
+    @DisplayName("test 32 bit Linux label computation")
+    void testComputeLabelsCanonicalLinuxArch() throws Exception {
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        assertPlatformDetails(details);
+    }
+
+    @Test
+    @DisplayName("test CanonicalLinuxArch stream")
+    void testCanonicalLinuxArchStream() throws IOException {
+        String unameOutput = "x86_64";
+        InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
+        assertThat(
+                platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH),
+                is("amd64"));
+    }
+
+    @Test
+    @DisplayName("test CanonicalLinuxArch stream ARM")
+    void testCanonicalLinuxArchStreamARM() throws IOException {
+        String unameOutput = "aarch64";
+        InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
+        assertThat(
+                platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH),
+                is(unameOutput));
+    }
+
+    @Test
+    @DisplayName("test CanonicalLinuxArch stream empty")
+    void testCanonicalLinuxArchStreamEmpty() throws IOException {
+        String unameOutput = "";
+        String expectedArch = "Expected-Arch";
+        InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
+        assertThat(
+                platformDetailsTask.getCanonicalLinuxArchStream(stream, expectedArch),
+                is(expectedArch));
+    }
+
+    @Test
+    @DisplayName("test Linux label computation without lsb_release")
+    void testComputeLabelsLinuxWithoutLsbRelease() throws Exception {
+        if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
+            return;
+        }
+        String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
+        LsbRelease release = new LsbRelease(unknown, unknown);
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
+        assertPlatformDetails(details);
+    }
+
+    @Test
+    @DisplayName("test Linux label computation with null lsb_release")
+    void testComputeLabelsLinuxWithNullLsbRelease() throws Exception {
+        if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
+            return;
+        }
+        LsbRelease release = null;
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
+        assertPlatformDetails(details);
+    }
+
+    @Test
+    @DisplayName("test Windows 32 bit empty second and third arguments")
+    void testCheckWindows32BitEmptyArgs() {
+        /* Always testing this case, no SPECIAL_CASE_ARCH needed */
+        assertThat(platformDetailsTask.checkWindows32Bit("x86", "", ""), is("x86"));
+    }
+
+    @Test
+    @DisplayName("test Windows 32 bit arbitrary arch")
+    void testCheckWindows32BitArbitraryArch() {
+        /* Always testing this case, no SPECIAL_CASE_ARCH needed */
+        assertThat(platformDetailsTask.checkWindows32Bit("not-x86", "", ""), is("not-x86"));
+    }
+
+    @Test
+    @DisplayName("test Windows 32 bit")
+    void testCheckWindows32Bit() {
+        /* Always testing this case, no SPECIAL_CASE_ARCH needed */
+        assertThat(platformDetailsTask.checkWindows32Bit("x86", "AMD64", ""), is("amd64"));
+    }
+
+    @Test
+    @DisplayName("test Windows 32 bit with amd64")
+    void testCheckWindows32BitAMD64SecondArgument() {
+        /* Always testing this case, no SPECIAL_CASE_ARCH needed */
+        assertThat(platformDetailsTask.checkWindows32Bit("x86", "x86", "AMD64"), is("amd64"));
+    }
+
+    @Test
+    @DisplayName("test operating system name")
+    void compareOSName() throws Exception {
+        if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
+            return;
+        }
+        String computedName =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy").getName();
+        String readName = platformDetailsTask.getReleaseIdentifier("ID");
+        assertThat(computedName, is(readName));
+    }
+
+    @Test
+    @DisplayName("test release identifier on missing file")
+    void getReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.setOsReleaseFile(new File("/this/file/does/not/exist"));
+        String name = platformDetailsTask.getReleaseIdentifier("ID");
+        assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read Debian version identifier missing file")
+    void getDebianVersionIdentifierMissingFileReturnsUnknownValue() throws Exception {
+        platformDetailsTask.setDebianVersion(new File("/this/file/does/not/exist"));
+        String version = platformDetailsTask.getDebianVersionIdentifier();
+        assertThat(version, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read Debian version identifier null file")
+    void getDebianVersionNullFileReturnsUnknownValue() throws Exception {
+        platformDetailsTask.setDebianVersion(null);
+        String version = platformDetailsTask.getDebianVersionIdentifier();
+        assertThat(version, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read Red Hat release identifier")
+    void getRedhatReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.setRedhatRelease(new File("/this/file/does/not/exist"));
+        String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
+        assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read Red Hat release identifier null file")
+    void getRedhatReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.setRedhatRelease(null);
+        String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
+        assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read Red Hat release identifier wrong file")
+    void getRedhatReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.setRedhatRelease(new File("/etc/hosts")); // Not redhat-release file
+        String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
+        assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read SUSE release identifier missing file")
+    void getSuseReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
+        platformDetailsTask.setSuseRelease(new File("/this/file/does/not/exist"));
+        String name = platformDetailsTask.getSuseReleaseIdentifier("ID");
+        assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read SUSE release identifier null file")
+    void getSuseReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
+        platformDetailsTask.setSuseRelease(null);
+        String name = platformDetailsTask.getSuseReleaseIdentifier("ID");
+        assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Read SUSE release identifier wrong file")
+    void getSuseReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
+        if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
+            return;
+        }
+        platformDetailsTask.setSuseRelease(new File("/etc/hosts")); // Not SuSE-release file
+        String name = platformDetailsTask.getSuseReleaseIdentifier("ID");
+        assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+    }
+
+    @Test
+    @DisplayName("Compare operating system version")
+    void compareOSVersion() throws Exception {
+        if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
+            return;
+        }
+        PlatformDetails details =
+                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        String version = platformDetailsTask.getReleaseIdentifier("VERSION_ID");
+        /* Check that the version string returned by getReleaseIdentifier
+         * is at least at the beginning of one of the detail values. Allow
+         * Debian 8, 9, and 10 and CentOS 7 to report their base version
+         * in the /etc/os-release file without reporting their incremental
+         * version
+         */
+        String foundValue = version;
+        if (details.getVersion().startsWith(version)) {
+            foundValue = details.getVersion();
+        }
+        /* If VERSION_ID has the unknown value then handle it as a special
+         * case.  Debian testing does not include a VERSION_ID value in
+         * the /etc/os-release file.  If there is no value for VERSION_ID,
+         * then confirm that the details are for Debian testing and skip
+         * the VERSION_ID assertion.
+         */
+        if (version.startsWith("unknown")) {
+            assertThat(details.getName(), is("Debian"));
+            assertThat(details.getVersion(), is("testing"));
+        } else {
+            assertThat(details.getVersion(), anyOf(is(version), is(foundValue)));
+        }
+    }
+
+    private boolean isWindows() {
+        return File.pathSeparatorChar == ';';
+    }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
@@ -36,25 +36,25 @@ import org.jvnet.hudson.test.JenkinsRule;
 /** @author robertc */
 public class PlatformLabelerTest {
 
-  @Rule public final JenkinsRule j = new JenkinsRule();
+    @Rule public final JenkinsRule j = new JenkinsRule();
 
-  @Test
-  public void testLookupCached() {
-    Collection<LabelAtom> expected = new HashSet<>();
-    expected.add(j.jenkins.getLabelAtom("foo"));
-    expected.add(j.jenkins.getLabelAtom("bar"));
-    NodeLabelCache.nodeLabels.put(j.jenkins, expected);
-    Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
-    assertThat(labels, is(expected));
-  }
-
-  @Test
-  public void testLookupUncached() throws Exception {
-    /* remove the Jenkins node from the cache */
-    if (NodeLabelCache.nodeLabels.containsKey(j.jenkins)) {
-      NodeLabelCache.nodeLabels.remove(j.jenkins);
+    @Test
+    public void testLookupCached() {
+        Collection<LabelAtom> expected = new HashSet<>();
+        expected.add(j.jenkins.getLabelAtom("foo"));
+        expected.add(j.jenkins.getLabelAtom("bar"));
+        NodeLabelCache.nodeLabels.put(j.jenkins, expected);
+        Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
+        assertThat(labels, is(expected));
     }
-    Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
-    assertThat(labels, is(empty()));
-  }
+
+    @Test
+    public void testLookupUncached() throws Exception {
+        /* remove the Jenkins node from the cache */
+        if (NodeLabelCache.nodeLabels.containsKey(j.jenkins)) {
+            NodeLabelCache.nodeLabels.remove(j.jenkins);
+        }
+        Collection<LabelAtom> labels = new PlatformLabeler().findLabels(j.jenkins);
+        assertThat(labels, is(empty()));
+    }
 }


### PR DESCRIPTION
## Format with git code format maven plugin instead of fmt

The aarch64 invocation of the `fmt` maven plugin fails with an invalid byte code message.  Try the git code format maven plugin as a replacement.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
