### PR TITLE
Test with better specified Debian images

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/10/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/10/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:10-slim
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y lsb-release
+FROM debian:10.7-slim
+RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/9.13/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/9.13/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:9-slim
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y lsb-release
+FROM debian:9.13-slim
+RUN apt-get update && apt-get install -y lsb-release


### PR DESCRIPTION
## Test with more precise Debian image versions

Allow dependabot a better chance of updating the version number in the Dockerfile.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
