### PR TITLE
Use more specific Oracle Linux 7 version

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/7.9/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/7.9/Dockerfile
@@ -1,2 +1,2 @@
-FROM oraclelinux:7-slim
+FROM oraclelinux:7.9
 RUN yum install -y redhat-lsb-core


### PR DESCRIPTION
## Use more specific Oracle Linux 7 Docker image

Use Oracle Linux 7.9 in Docker `FROM` statement so that dependabot can detect upgrades and propose pull requests for those upgrades.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
