### PR TITLE
Use most recent checkstyle tool version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.1.2</version>
+        <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.40</version>
+            </dependency>
+          </dependencies>
         <configuration>
           <configLocation>google_checks.xml</configLocation>
           <failOnViolation>true</failOnViolation>


### PR DESCRIPTION
## Use latest checkstyle tool release

The maven checkstyle plugin defaults to use an older version of the checkstyle tool.  Configure the plugin to use the [most recent release](https://checkstyle.sourceforge.io/releasenotes.html) of the checkstyle tool.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
