### PR TITLE
Update Alpine Linux test data and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Labels commonly include operating system name, version, and architecture.
 
 | Platform                   | OS Name            | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
-| Alpine                     | `Alpine`           | `3.12.3`       | `amd64`      |
-| Alpine                     | `Alpine`           | `3.13.2`       | `amd64`      |
+| Alpine 3.12                | `Alpine`           | `3.12.4`       | `amd64`      |
+| Alpine 3.13                | `Alpine`           | `3.13.2`       | `amd64`      |
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      |
 | CentOS 7                   | `CentOS`           | `7.8.2003`     | `amd64`      |
 | CentOS 8                   | `CentOS`           | `8.2.2004`     | `amd64`      |

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.5/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.5/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.10.5

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.6/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.6/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.10.6

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.6/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.6/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.12.3
-PRETTY_NAME="Alpine Linux v3.12"
+VERSION_ID=3.10.6
+PRETTY_NAME="Alpine Linux v3.10"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.3/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.3/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.12.3

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.4/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.4/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.12.4

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.4/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.4/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.10.5
-PRETTY_NAME="Alpine Linux v3.10"
+VERSION_ID=3.12.4
+PRETTY_NAME="Alpine Linux v3.12"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"


### PR DESCRIPTION
## Update Alpine Linux test data and documentation

Alpine 3.10.6 and Alpine 3.12.4 are the most recent Alpine releases.  Use them as the test data.  Include in the README also.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test data
