### PR TITLE
Add openSUSE Leap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Labels commonly include operating system name, version, and architecture.
 | FreeBSD 11                 | `freebsd`          | `11.4-STABLE`  | `amd64`      |
 | FreeBSD 12                 | `freebsd`          | `12.2-RELEASE` | `amd64`      |
 | Linux Mint 19.3            | `LinuxMint`        | `19.03`        | `amd64`      |
+| openSUSE Leap              | `openSUSE`         | `15.2`         | `amd64`      |
 | Oracle Linux 7             | `OracleServer`     | `7.9`          | `amd64`      |
 | Oracle Linux 8             | `OracleServer`     | `8.3`          | `amd64`      |
 | Raspbian 9                 | `Raspbian`         | `9.13`         | `arm`        |


### PR DESCRIPTION
## Add openSUSE Leap example to docs

Include an openSUSE Leap example in the documentation.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Documentation
