### PR TITLE
Require Jenkins 2.263 as minimum version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.249.3', '2.263.1', '2.263.2', '2.263.3', '2.263.4', '2.277', '2.278', '2.279' ]
+def testJenkinsVersions = [ '2.263.1', '2.263.2', '2.263.3', '2.263.4', '2.277.1', '2.284' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.249.1</jenkins.version>
+    <jenkins.version>2.263.1</jenkins.version>
     <java.level>8</java.level>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
@@ -56,7 +56,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
+        <artifactId>bom-2.263.x</artifactId>
         <version>26</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require at least Jenkins 2.263

Currently recommended as one of the minimum versions by [choosing a Jenkins baseline](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
