### PR TITLE
Document and test Ubuntu 21.04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -283,10 +283,24 @@ updates:
   - skip-changelog
   ignore:
     - dependency-name: "Dockerfile"
-      versions: ["20.x"]
+      versions: ["20.x", "21.x"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/20.04"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  target-branch: master
+  reviewers:
+  - MarkEWaite
+  labels:
+  - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: ["21.x"]
+
+- package-ecosystem: docker
+  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Labels commonly include operating system name, version, and architecture.
 | Ubuntu 18                  | `Ubuntu`           | `18.04`        | `ppc64le`    |
 | Ubuntu 18                  | `Ubuntu`           | `18.04`        | `s390x`      |
 | Ubuntu 20                  | `Ubuntu`           | `20.04`        | `amd64`      |
+| Ubuntu 21                  | `Ubuntu`           | `21.04`        | `amd64`      |
 | Windows 10                 | `windows`          | `10.0`         | `amd64`      |
 
 On Linux computers, the plugin uses the output of the [`lsb_release`](https://linux.die.net/man/1/lsb_release) command.

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:hirsute-20210422
+RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04/lsb_release-a
@@ -1,0 +1,5 @@
+No LSB modules are available.
+Distributor ID:	Ubuntu
+Description:	Ubuntu 21.04
+Release:	21.04
+Codename:	hirsute

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04/os-release
@@ -1,0 +1,12 @@
+NAME="Ubuntu"
+VERSION="21.04 (Hirsute Hippo)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 21.04"
+VERSION_ID="21.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=hirsute
+UBUNTU_CODENAME=hirsute


### PR DESCRIPTION
## Document and test Ubuntu 21.04

Document and test the new desktop operating system release from Ubuntu, Ubuntu 21.04, "Hirsute Hippo".

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Dependency update
