### PR TITLE
Exclude by semantic version range

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,7 @@ updates:
   - skip-changelog
   ignore:
   - dependency-name: org.slf4j*
-    versions:
-    - ">= 0"
+    versions: [">= 0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.9"
@@ -26,6 +25,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 3.11.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.7"
@@ -37,6 +39,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 3.13.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.5"
@@ -70,6 +75,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 8.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/centos/8.3.2011"
@@ -103,6 +111,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 11.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/9.13"
@@ -114,6 +125,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 10.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing"
@@ -147,6 +161,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 33.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/fedora/33"
@@ -213,6 +230,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 8.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.3"
@@ -246,6 +266,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 8.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/18.04"
@@ -257,6 +280,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 20.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/20.04"
@@ -268,6 +294,9 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 21.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/21.04"


### PR DESCRIPTION
## Fix dependabot version exclusions

Configure Dependabot to ignore versions that are newer than desired.  See working example at https://github.com/jenkinsci/jenkins/pull/5529

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
