### PR TITLE
Remove Alpine 3.10 test data

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,20 +16,6 @@ updates:
     versions: [">= 0"]
 
 - package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.9"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-  ignore:
-    - dependency-name: "Dockerfile"
-      versions: [">= 3.11.0"]
-
-- package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.7"
   schedule:
     interval: weekly

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.9/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.9/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.10.9

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.9/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.10.9/os-release
@@ -1,6 +1,0 @@
-NAME="Alpine Linux"
-ID=alpine
-VERSION_ID=3.10.9
-PRETTY_NAME="Alpine Linux v3.10"
-HOME_URL="https://alpinelinux.org/"
-BUG_REPORT_URL="https://bugs.alpinelinux.org/"


### PR DESCRIPTION
## Remove Alpine 3.10 test data

Alpine 3.10 no longer receives security updates

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
