### PR TITLE
Use rhel7.9 test data

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/rhel7/rhel/7.7/redhat-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/rhel7/rhel/7.7/redhat-release
@@ -1,1 +1,0 @@
-Red Hat Enterprise Linux Server release 7.7 (Maipo)

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/rhel7/rhel/7.9/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/rhel7/rhel/7.9/os-release
@@ -1,17 +1,17 @@
 NAME="Red Hat Enterprise Linux Server"
-VERSION="7.7 (Maipo)"
+VERSION="7.9 (Maipo)"
 ID="rhel"
 ID_LIKE="fedora"
 VARIANT="Server"
 VARIANT_ID="server"
-VERSION_ID="7.7"
-PRETTY_NAME="Red Hat Enterprise Linux Server 7.7 (Maipo)"
+VERSION_ID="7.9"
+PRETTY_NAME="Red Hat Enterprise Linux Server 7.9 (Maipo)"
 ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:redhat:enterprise_linux:7.7:GA:server"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.9:GA:server"
 HOME_URL="https://www.redhat.com/"
 BUG_REPORT_URL="https://bugzilla.redhat.com/"
 
 REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
-REDHAT_BUGZILLA_PRODUCT_VERSION=7.7
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.9
 REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
-REDHAT_SUPPORT_PRODUCT_VERSION="7.7"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.9"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/rhel7/rhel/7.9/redhat-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/rhel7/rhel/7.9/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux Server release 7.9 (Maipo)


### PR DESCRIPTION
## Use RHEL 7.9 test data

Red Hat Enterprise Linux 7.7 ends support in August 2021, not need to include it in test data.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
