### PR TITLE
Add Debian 11 test data

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:bullseye-20210621-slim
+RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/lsb_release-a
@@ -1,0 +1,5 @@
+No LSB modules are available.
+Distributor ID:	Debian
+Description:	Debian GNU/Linux 11 (bullseye)
+Release:	11
+Codename:	bullseye

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
+NAME="Debian GNU/Linux"
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+VERSION_CODENAME=bullseye
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
## Add Debian 11 test data

The 'bullseye' docker image has been published.  Use it to provide test data for Debian 11.`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
