### PR TITLE
[JENKINS-66167] Fix NodeLabelCache null pointer exception

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -159,6 +159,10 @@ public class NodeLabelCache extends ComputerListener {
 
         final Jenkins jenkins = Jenkins.getInstanceOrNull();
 
+        if (pp == null || jenkins == null) {
+            return result;
+        }
+
         if (labelConfig.isArchitecture()) {
             result.add(jenkins.getLabelAtom(pp.getArchitecture()));
         }


### PR DESCRIPTION
## [JENKINS-66167](https://issues.jenkins.io/browse/JENKINS-66167) Fix NodeLabelCache null pointer exception
    
Weak hash map acts as though a separate thread might remove entries from the map at any time.  Check for null before use.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
