### PR TITLE
Test with Alpine 3.14.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,32 +16,7 @@ updates:
     versions: [">= 0"]
 
 - package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.7"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-  ignore:
-    - dependency-name: "Dockerfile"
-      versions: [">= 3.13.0"]
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.5"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.1"
+  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.2"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -61,59 +36,6 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/centos/7.9.2009"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-  ignore:
-    - dependency-name: "Dockerfile"
-      versions: [">= 8.0.0"]
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/centos/8.3.2011"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/9.13"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-  ignore:
-    - dependency-name: "Dockerfile"
-      versions: [">= 10.0.0"]
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/10"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-  ignore:
-    - dependency-name: "Dockerfile"
-      versions: [">= 11.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11"
@@ -139,17 +61,6 @@ updates:
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/fedora/33"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -216,20 +127,6 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
-
-- package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/18.04"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-  ignore:
-    - dependency-name: "Dockerfile"
-      versions: [">= 20.0.0"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/20.04"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Labels commonly include operating system name, version, and architecture.
 | -------------------------- | ------------------ | -------------- | ------------ |
 | Alpine 3.12                | `Alpine`           | `3.12.7`       | `amd64`      |
 | Alpine 3.13                | `Alpine`           | `3.13.5`       | `amd64`      |
-| Alpine 3.14                | `Alpine`           | `3.14.1`       | `amd64`      |
+| Alpine 3.14                | `Alpine`           | `3.14.2`       | `amd64`      |
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      |
 | CentOS 7                   | `CentOS`           | `7.9.2009`     | `amd64`      |
 | CentOS 8                   | `CentOS`           | `8.3.2011`     | `amd64`      |

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.1/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.1/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.14.1

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.2/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.2/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.14.2

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.2/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.2/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.14.1
+VERSION_ID=3.14.2
 PRETTY_NAME="Alpine Linux v3.14"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"


### PR DESCRIPTION

## Test with Alpine Linux 3.14.2

- Remove outdated dependabot checks
- Test with Alpine Linux 3.14.2 instead of 3.14.1

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test update
