### PR TITLE
Use updated terminology in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.263.1', '2.263.2', '2.263.3', '2.263.4', '2.277.1', '2.284' ]
+def testJenkinsVersions = [ '2.263.1', '2.277.1', '2.289.1', '2.303.1', '2.308' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -45,7 +45,7 @@ public class ConfigurationTest {
         nodeLabelCache.onConfigurationChange();
 
         Collection<LabelAtom> expected = new HashSet<>();
-        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getSelfLabel());
         expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
@@ -66,7 +66,7 @@ public class ConfigurationTest {
         nodeLabelCache.onConfigurationChange();
 
         Collection<LabelAtom> expected = new HashSet<>();
-        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getSelfLabel());
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
         expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
 
@@ -84,7 +84,7 @@ public class ConfigurationTest {
         nodeLabelCache.onConfigurationChange();
 
         Collection<LabelAtom> expected = new HashSet<>();
-        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getSelfLabel());
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
         expected.add(r.jenkins.getLabelAtom(platformDetails.getVersion()));
         expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
@@ -118,7 +118,7 @@ public class ConfigurationTest {
         nodeLabelCache.onConfigurationChange();
 
         Collection<LabelAtom> expected = new HashSet<>();
-        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getSelfLabel());
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
         expected.add(r.jenkins.getLabelAtom(platformDetails.getName()));
         expected.add(r.jenkins.getLabelAtom(platformDetails.getNameVersion()));
@@ -148,7 +148,7 @@ public class ConfigurationTest {
         nodeLabelCache.onConfigurationChange();
 
         Collection<LabelAtom> expected = new HashSet<>();
-        expected.add(r.jenkins.getLabelAtom("master"));
+        expected.add(r.jenkins.getSelfLabel());
         expected.add(r.jenkins.getLabelAtom(platformDetails.getArchitecture()));
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();


### PR DESCRIPTION
## Use updated terminology to test with Jenkins 2.308 and newer LTS versions.

Check that the expected label of the controller is detected, without assuming that the expected label uses the less inclusive term 'master'.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tests
