### PR TITLE
Use bullseye 20210902

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ For example:
 | Platform                   | Operating System   | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
 | CentOS 7                   | `CentOS`           | `7`            | `amd64`      |
-| Debian testing             | `Debian`           | `bullseye`     | `amd64`      |
-| Debian unstable            | `Debian`           | `bullseye`     | `amd64`      |
+| Debian testing             | `Debian`           | `bookworm`     | `amd64`      |
+| Debian unstable            | `Debian`           | `bookworm`     | `amd64`      |
 
 The types of labels can be configured globally and per agent with the 'Automatic Platform Labels' setting.
 

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/10/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/10/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:buster-20210816-slim
+FROM debian:buster-20210902-slim
 RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:bullseye-20210816-slim
+FROM debian:bullseye-20210902-slim
 RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/9.13/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/9.13/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:stretch-20210816-slim
+FROM debian:stretch-20210902-slim
 RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:testing-20210816-slim
+FROM debian:testing-20210902-slim
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
@@ -1,5 +1,5 @@
 No LSB modules are available.
 Distributor ID:	Debian
-Description:	Debian GNU/Linux bullseye/sid
+Description:	Debian GNU/Linux bookworm/sid
 Release:	testing
-Codename:	bullseye
+Codename:	bookworm

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
@@ -1,4 +1,4 @@
-PRETTY_NAME="Debian GNU/Linux bullseye/sid"
+PRETTY_NAME="Debian GNU/Linux bookworm/sid"
 NAME="Debian GNU/Linux"
 ID=debian
 HOME_URL="https://www.debian.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:unstable-20210816-slim
+FROM debian:unstable-20210902-slim
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
@@ -1,5 +1,5 @@
 No LSB modules are available.
 Distributor ID:	Debian
-Description:	Debian GNU/Linux bullseye/sid
+Description:	Debian GNU/Linux bookworm/sid
 Release:	unstable
 Codename:	sid

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
@@ -1,4 +1,4 @@
-PRETTY_NAME="Debian GNU/Linux bullseye/sid"
+PRETTY_NAME="Debian GNU/Linux bookworm/sid"
 NAME="Debian GNU/Linux"
 ID=debian
 HOME_URL="https://www.debian.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/update_dependabot.sh
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/update_dependabot.sh
@@ -26,7 +26,7 @@ updates:
     - ">= 0"
 END-OF-DEPENDABOT-YML
 
-for file in $(git ls-files -- *Dockerfile | grep -E -v 'clearlinux|linuxmint|opensuse-tumbleweed|scientific' | sort -V); do
+for file in $(git ls-files -- *Dockerfile | grep -E -v 'alpine/3.12|alpine/3.13|centos|clearlinux|debian/9|debian/10|fedora/33|linuxmint|opensuse-tumbleweed|scientific|ubuntu/18' | sort -V); do
   dir=$(dirname $file)
   cat >> .github/dependabot.yml <<END-OF-DEPENDABOT-YML
 


### PR DESCRIPTION
## Use latest Debian images

* Use Debian 2021-09-02 builds
* Dependabot generator update
* Update Debian test data

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
