### PR TITLE
Use https:// instead of git:// in pom, update test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Labels commonly include operating system name, version, and architecture.
 
 | Platform                   | OS Name            | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
-| Alpine 3.12                | `Alpine`           | `3.12.7`       | `amd64`      |
-| Alpine 3.13                | `Alpine`           | `3.13.5`       | `amd64`      |
+| Alpine 3.12                | `Alpine`           | `3.12.8`       | `amd64`      |
+| Alpine 3.13                | `Alpine`           | `3.13.6`       | `amd64`      |
 | Alpine 3.14                | `Alpine`           | `3.14.2`       | `amd64`      |
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      |
 | CentOS 7                   | `CentOS`           | `7.9.2009`     | `amd64`      |
-| CentOS 8                   | `CentOS`           | `8.3.2011`     | `amd64`      |
-| Clear Linux                | `clear-linux-os`   | `34990`        | `amd64`      |
+| CentOS 8                   | `CentOS`           | `8.4.2105`     | `amd64`      |
+| Clear Linux                | `clear-linux-os`   | `35030`        | `amd64`      |
 | Debian 9                   | `Debian`           | `9.13`         | `amd64`      |
 | Debian 10                  | `Debian`           | `10`           | `aarch64`    |
 | Debian 10                  | `Debian`           | `10`           | `amd64`      |

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/platformlabeler-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/platformlabeler-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/platformlabeler-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/platformlabeler-plugin</url>
     <tag>${scmTag}</tag>

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.7/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.7/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.12.7

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.8/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.8/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.12.8

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.8/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.8/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.12.7
+VERSION_ID=3.12.8
 PRETTY_NAME="Alpine Linux v3.12"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.5/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.5/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.13.5

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.6/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.6/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.13.6

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.6/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.6/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.13.5
+VERSION_ID=3.13.6
 PRETTY_NAME="Alpine Linux v3.13"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/centos/8.4.2105/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/centos/8.4.2105/Dockerfile
@@ -1,2 +1,2 @@
-FROM centos:8.3.2011
+FROM centos:8.4.2105
 RUN yum install -y redhat-lsb-core

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/centos/8.4.2105/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/centos/8.4.2105/lsb_release-a
@@ -1,5 +1,5 @@
 LSB Version:	:core-4.1-amd64:core-4.1-noarch
 Distributor ID:	CentOS
-Description:	CentOS Linux release 8.3.2011
-Release:	8.3.2011
+Description:	CentOS Linux release 8.4.2105
+Release:	8.4.2105
 Codename:	n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/18.04/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/18.04/Dockerfile
@@ -1,2 +1,2 @@
-FROM ubuntu:bionic-20210723
+FROM ubuntu:bionic-20210827
 RUN apt-get update && apt-get install -y lsb-release


### PR DESCRIPTION
## Use https instead of git protocol in pom, update test data

GitHub is deprecating git protocol access to their repositories.

* Use https instead of git:// protocol in pom
* Test with latest operating system images

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Documentation and tests
