### PR TITLE
Check integer portion of SUSE version

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -271,7 +271,9 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             if (computedName.equals("SUSE LINUX")) {
                 computedName = "SUSE";
                 try {
-                    int intVersion = Integer.parseInt(computedVersion);
+                    String integerPortion =
+                            computedVersion.replaceAll("([0-9]+)([.][0-9]+)*", "$1");
+                    int intVersion = Integer.parseInt(integerPortion);
                     if (intVersion <= 11) {
                         String newVersion = getSuseReleaseIdentifier("VERSION_ID");
                         if (!newVersion.equals(UNKNOWN_VALUE_STRING)) {

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/10.2/SuSE-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/10.2/SuSE-release
@@ -1,0 +1,5 @@
+SUSE Linux Enterprise Server 10 (x86_64)
+VERSION = 10
+PATCHLEVEL = 2
+# This file is deprecated and will be removed in a future service pack or release.
+# Please check /etc/os-release for details about this release.

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/10.2/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/10.2/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:    n/a
+Distributor ID: SUSE LINUX
+Description:    SUSE Linux Enterprise Server 10 SP2
+Release:        10.2
+Codename:       n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/10.2/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/sles/10.2/os-release
@@ -1,0 +1,7 @@
+NAME="SLES"
+VERSION="10-SP2"
+VERSION_ID="10.2"
+PRETTY_NAME="SUSE Linux Enterprise Server 10 SP2"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp1"


### PR DESCRIPTION
## Check integer portion of SUSE version

SUSE 15.2 and SUSE 12.2 were skipping the integer check when the string is a floating point number.  Use an integer check instead.

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
* [x] I have referenced the Jira issue related to my changes in one or more commit messages
* [x] I have added tests that verify my changes
* [x] Unit tests pass locally with my changes
* [x] I have added documentation as necessary
* [x] No spotbugs warnings were introduced with my changes
* [x] I have interactively tested my changes

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
