### PR TITLE
Fix coverage reporting with parent pom 4.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.27</version>
+    <version>4.28</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Fix coverage reporting with parent pom 4.28

Parent pom 4.27 inadvertently disabled coverage reporting.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
