### PR TITLE
Remove unused slf4jVersion property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <junit.jupiter.version>5.8.1</junit.jupiter.version>
-    <slf4jVersion>1.7.26</slf4jVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Low</spotbugs.threshold>


### PR DESCRIPTION
## Remove unused slf4j property

The report from `mvn help:effective-pom` shows that the slf4j version value used in the pom is newer than the value of this property.  There is no location in the effective pom that references this value.

The slf4j version in the effective pom is 1.7.30 even though this property had 1.7.26 as its value.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
