### PR TITLE
Test Java 11 on Linux, Java 8 on Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,11 @@ if (env.JENKINS_URL.contains('markwaite.net')) {
     // Use advanced buildPlugin on markwaite.net
     buildPlugin(configurations: subsetConfiguration, failFast: false)
 } else {
-    // Use simple buildPlugin on ci.jenkins.io and elsewhere
-    buildPlugin()
+    // Use simple buildPlugin elsewhere
+    buildPlugin(
+        configurations: [
+            [platform: 'linux',   jdk: '11'],
+            [platform: 'windows', jdk:  '8']
+        ]
+    )
 }


### PR DESCRIPTION
## Test Java 11 on Linux, Java 8 on Windows

Assure both key platforms and key Java versions are tested without duplicating for cases that have not shown issues in the past.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
