### PR TITLE
Add gitpod support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 .classpath
+.factorypath
 .settings
 .project
 *.iml

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: mvn install -DskipTests=false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}


### PR DESCRIPTION
## Experiment with gitpod for platformlabeler plugin development

Add a gitpod definition file for plugin development on gitpod.io.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [ ] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tooling
