### PR TITLE
Use spotbugs anno from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,18 +78,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <version>4.4.2</version>
-      <exclusions>
-        <exclusion><!-- prevent transitive inclusion of jsr305 -->
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Simpligfy pom by removing spotbugs annotation

Simplify the pom by removing the spotbugs annotation dependency.  Rely on the parent pom to provide it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
