### PR TITLE
Auto-assign pull request labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+chore:
+- .gitattributes
+- .github/**/*
+- .gitignore
+- .mvn/**/*
+- .pre-commit-config.yaml
+- .sonarcloud.properties
+- .vscode/**/*
+- Jenkinsfile
+
+dependencies:
+- pom.xml
+
+documentation:
+- CONTRIBUTING.md
+- README.md
+- LICENSE.txt
+
+test:
+- src/**/*.sh
+- src/**/Dockerfile
+- src/**/lsb_release-a
+- src/**/os-release

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Automatically assign labels to pull requests

Assigns labels to maintenance changes and to test changes.  Can't assign enhancement and fix labels automatically.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
