### PR TITLE
Stop dependabot checks of SUSE 15.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,17 +71,6 @@ updates:
   - skip-changelog
 
 - package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/opensuse-leap/15.3"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-
-- package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/7.9"
   schedule:
     interval: weekly


### PR DESCRIPTION
## Stop dependabot checks for OpenSUSE

No finer version info than '15.3' for OpenSUSE Docker images, no value checking for updates.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
