### PR TITLE
Add help for configuration checkbox

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,6 +12,7 @@ documentation:
 - CONTRIBUTING.md
 - README.md
 - LICENSE.txt
+- src/main/**/*.html
 
 test:
 - src/**/*.sh

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty/help.html
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerNodeProperty/help.html
@@ -1,0 +1,8 @@
+<p>Adds labels to Jenkins agents based on characteristics of the operating system running the agent.</p>
+
+<p>
+  Labels include operating system name, version, and architecture by default.
+  Label creation can be controlled globally from the "Configure System" page of "Manage Jenkins".
+  Label creation can be controlled on each agent from the "Configure" page of each agent.
+  Label settings on the agent take priority over global agent label settings.
+</p>


### PR DESCRIPTION
## Add online help for configuration checkbox

Help already exists for the fields of the checkbox, but not for the checkbox that makes the fields visible.

* Add online help for configuration checkbox
* Add documentation label to help files

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation
