### PR TITLE
Enable pmd and cut and paste detector reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>0.8C</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <junit.jupiter.version>5.8.1</junit.jupiter.version>
+    <pmdVersion>6.40.0</pmdVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -135,6 +136,27 @@
   </pluginRepositories>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>3.15.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-core</artifactId>
+              <version>${pmdVersion}</version>
+            </dependency>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-java</artifactId>
+              <version>${pmdVersion}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <!-- Fail build on pom formatting errors -->
       <!-- Fix with mvn tidy:pom -->
@@ -230,6 +252,7 @@
         <executions>
           <execution>
             <goals>
+              <goal>check</goal>
               <goal>cpd-check</goal>
             </goals>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,18 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.15.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>cpd-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -34,11 +34,15 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** Linux standard base release class. Provides distributor ID and release. */
 public class LsbRelease {
     @NonNull private final String distributorId;
     @NonNull private final String release;
+
+    private static final Logger LOGGER = Logger.getLogger(LsbRelease.class.getName());
 
     /** Extract distributor ID and release for current platform. */
     public LsbRelease() {
@@ -47,7 +51,7 @@ public class LsbRelease {
             Process process = new ProcessBuilder("lsb_release", "-a").start();
             readLsbReleaseOutput(process.getInputStream(), newProps);
         } catch (IOException e) {
-            // IGNORE
+            LOGGER.log(Level.FINEST, "lsb_release execution failed", e);
         }
         this.distributorId =
                 newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -468,10 +468,8 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
                     new BufferedReader(
                             Files.newBufferedReader(
                                     debianVersion.toPath(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = br.readLine()) != null) {
-                    return line.trim();
-                }
+                String line = br.readLine();
+                return line != null ? line.trim() : UNKNOWN_VALUE_STRING;
             } catch (IOException notFound) {
                 return UNKNOWN_VALUE_STRING;
             }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -39,6 +39,8 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jenkins.security.Roles;
@@ -46,6 +48,8 @@ import org.jenkinsci.remoting.RoleChecker;
 
 /** Compute labels based on details computed on the agent. */
 class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
+
+    private static final Logger LOGGER = Logger.getLogger(PlatformDetailsTask.class.getName());
 
     private static final String RELEASE = "release";
     private static final String VERSION = "VERSION =";
@@ -128,6 +132,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             return getCanonicalLinuxArchStream(p.getInputStream(), arch);
         } catch (IOException | InterruptedException e) {
             /* Return arch instead of throwing an exception */
+            LOGGER.log(Level.FINEST, "uname -m failed", e);
         }
         return arch;
     }
@@ -282,6 +287,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
                     }
                 } catch (NumberFormatException nfe) {
                     // Ignore NumberFormatException
+                    LOGGER.log(Level.FINEST, "number format exception", nfe);
                 }
             }
             if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
@@ -373,6 +379,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             }
         } catch (IOException notFound) {
             // Ignore IOException
+            LOGGER.log(Level.FINEST, "os-release not found", notFound);
         }
         return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
     }
@@ -404,6 +411,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             }
         } catch (IOException notFound) {
             // Ignore IOException
+            LOGGER.log(Level.FINEST, "redhat-release not found", notFound);
         }
         return PREFERRED_LINUX_OS_NAMES.getOrDefault(value, value);
     }
@@ -485,6 +493,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             }
         } catch (IOException | InterruptedException e) {
             /* Return version instead of throwing an exception */
+            LOGGER.log(Level.FINEST, "freebsd version exception", e);
         }
         return version;
     }


### PR DESCRIPTION
## Enable pmd and copy and paste detector report

Use pmd to detect copy and paste code in the plugin and other warnings.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Tools
