### PR TITLE
Reduce Oracle test image size

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/7.9/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/7.9/Dockerfile
@@ -1,2 +1,5 @@
-FROM oraclelinux:7.9
+# https://github.com/oracle/container-images/pkgs/container/oraclelinux
+# recommends 7-slim. It is unfortunate that it does not have a more precise
+# version number.
+FROM ghcr.io/oracle/oraclelinux:7-slim
 RUN yum install -y redhat-lsb-core

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.4/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.4/Dockerfile
@@ -1,2 +1,5 @@
-FROM oraclelinux:8.4
-RUN yum install -y redhat-lsb-core
+# https://github.com/oracle/container-images/pkgs/container/oraclelinux
+# recommends 8-slim. It is unfortunate that it does not have a more precise
+# version number.
+FROM ghcr.io/oracle/oraclelinux:8-slim
+RUN microdnf install -y redhat-lsb-core


### PR DESCRIPTION
## Use slim to reduce Oracle Linux test image size

https://github.com/oracle/container-images/pkgs/container/oraclelinux recommends slim images

Also uses GitHub container registry instead of Docker registry to reduce the load on Docker container registry.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
