### PR TITLE
Add mutation testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,12 @@ Please don't introduce new spotbugs output.
 * `mvn spotbugs:check` to analyze project using [Spotbugs](https://spotbugs.github.io)
 * `mvn spotbugs:gui` to review report using GUI
 
+## Mutation Testing
+
+PIT mutation testing is available as a maven target.
+
+* `mvn org.pitest:pitest-maven:mutationCoverage` to perform mutation testing and generate a report
+
 ## Code Formatting
 
 Code formatting in the Platform Labeler plugin is maintained by the git code format maven plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,36 @@
           <reuseForks>true</reuseForks>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.7.3</version>
+      </plugin>
     </plugins>
   </build>
+  <!-- <profiles> -->
+  <!--   <profile> -->
+  <!--     <id>pitest</id> -->
+  <!--     <build> -->
+  <!--       <plugins> -->
+  <!--         <plugin> -->
+  <!--           <groupId>org.pitest</groupId> -->
+  <!--           <artifactId>pitest-maven</artifactId> -->
+  <!--           <version>1.7.3</version> -->
+  <!--           <configuration> -->
+  <!--             <executions> -->
+  <!--               <execution> -->
+  <!--                 <id>pitest</id> -->
+  <!--                 <phase>test</phase> -->
+  <!--                 <goals> -->
+  <!--                   <goal>mutationCoverage</goal> -->
+  <!--                 </goals> -->
+  <!--               </execution> -->
+  <!--             </executions> -->
+  <!--           </configuration> -->
+  <!--         </plugin> -->
+  <!--       </plugins> -->
+  <!--     </build> -->
+  <!--   </profile> -->
+  <!-- </profiles> -->
 </project>

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -192,8 +192,7 @@ public class PlatformDetailsTaskTest {
     @Test
     @DisplayName("test release identifier on missing file")
     void getReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
         platformDetailsTask.setOsReleaseFile(new File("/this/file/does/not/exist"));
         String name = platformDetailsTask.getReleaseIdentifier("ID");
         assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
@@ -218,8 +217,7 @@ public class PlatformDetailsTaskTest {
     @Test
     @DisplayName("Read Red Hat release identifier")
     void getRedhatReleaseIdentifierMissingFileReturnsUnknownValue() throws Exception {
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
         platformDetailsTask.setRedhatRelease(new File("/this/file/does/not/exist"));
         String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
         assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
@@ -228,8 +226,7 @@ public class PlatformDetailsTaskTest {
     @Test
     @DisplayName("Read Red Hat release identifier null file")
     void getRedhatReleaseIdentifierNullFileReturnsUnknownValue() throws Exception {
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
         platformDetailsTask.setRedhatRelease(null);
         String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
         assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));
@@ -238,8 +235,7 @@ public class PlatformDetailsTaskTest {
     @Test
     @DisplayName("Read Red Hat release identifier wrong file")
     void getRedhatReleaseIdentifierWrongFileReturnsUnknownValue() throws Exception {
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
         platformDetailsTask.setRedhatRelease(new File("/etc/hosts")); // Not redhat-release file
         String name = platformDetailsTask.getRedhatReleaseIdentifier("ID");
         assertThat(name, is(PlatformDetailsTask.UNKNOWN_VALUE_STRING));

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -38,6 +38,8 @@ public class PlatformDetailsTest {
     private String windowsFeatureUpdate;
     private PlatformDetails details;
 
+    @Deprecated private PlatformDetails fewerDetails;
+
     public PlatformDetailsTest() {}
 
     @BeforeEach
@@ -47,6 +49,7 @@ public class PlatformDetailsTest {
         version = randomVersion();
         windowsFeatureUpdate = randomWindowsFeatureUpdate();
         details = new PlatformDetails(name, arch, version, windowsFeatureUpdate);
+        fewerDetails = new PlatformDetails(name, arch, version);
     }
 
     @Test
@@ -55,13 +58,31 @@ public class PlatformDetailsTest {
     }
 
     @Test
+    @Deprecated
+    void testGetNameFewerDetails() {
+        assertThat(fewerDetails.getName(), is(name));
+    }
+
+    @Test
     void testGetArchitecture() {
         assertThat(details.getArchitecture(), is(arch));
     }
 
     @Test
+    @Deprecated
+    void testGetArchitectureFewerDetails() {
+        assertThat(fewerDetails.getArchitecture(), is(arch));
+    }
+
+    @Test
     void testGetVersion() {
         assertThat(details.getVersion(), is(version));
+    }
+
+    @Test
+    @Deprecated
+    void testGetVersionFewerDetails() {
+        assertThat(fewerDetails.getVersion(), is(version));
     }
 
     @Test

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -38,8 +38,6 @@ public class PlatformDetailsTest {
     private String windowsFeatureUpdate;
     private PlatformDetails details;
 
-    @Deprecated private PlatformDetails fewerDetails;
-
     public PlatformDetailsTest() {}
 
     @BeforeEach
@@ -49,7 +47,6 @@ public class PlatformDetailsTest {
         version = randomVersion();
         windowsFeatureUpdate = randomWindowsFeatureUpdate();
         details = new PlatformDetails(name, arch, version, windowsFeatureUpdate);
-        fewerDetails = new PlatformDetails(name, arch, version);
     }
 
     @Test
@@ -60,6 +57,7 @@ public class PlatformDetailsTest {
     @Test
     @Deprecated
     void testGetNameFewerDetails() {
+        PlatformDetails fewerDetails = new PlatformDetails(name, arch, version);
         assertThat(fewerDetails.getName(), is(name));
     }
 
@@ -71,6 +69,7 @@ public class PlatformDetailsTest {
     @Test
     @Deprecated
     void testGetArchitectureFewerDetails() {
+        PlatformDetails fewerDetails = new PlatformDetails(name, arch, version);
         assertThat(fewerDetails.getArchitecture(), is(arch));
     }
 
@@ -82,6 +81,7 @@ public class PlatformDetailsTest {
     @Test
     @Deprecated
     void testGetVersionFewerDetails() {
+        PlatformDetails fewerDetails = new PlatformDetails(name, arch, version);
         assertThat(fewerDetails.getVersion(), is(version));
     }
 

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/WindowsReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/WindowsReleaseTest.java
@@ -42,28 +42,27 @@ public class WindowsReleaseTest {
     }
 
     @Test
-    void testReleaseFile() {
+    void testReleaseFromFile() {
         assertThat(windowsReleaseFile.release(), is("1903"));
-    }
-
-    @Test
-    void testReleaseNotWindows() {
-        if (!isWindows()) {
-            assertThat(
-                    windowsRelease.release(), is(PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING));
-        }
     }
 
     @Test
     void testRelease() {
         if (isWindows()) {
             assertThat(windowsRelease.release(), matchesPattern("[12][0-9][0-9][0-9]"));
+        } else {
+            String expected = PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING;
+            assertThat(windowsRelease.release(), is(expected));
         }
     }
 
     @Test
     void testDistributorId() {
         assertThat(windowsRelease.distributorId(), is("Microsoft"));
+    }
+
+    @Test
+    void testDistributorIdFromFile() {
         assertThat(windowsReleaseFile.distributorId(), is("Microsoft"));
     }
 


### PR DESCRIPTION
## Add [PIT mutation testing](https://pitest.org/)

Allow PIT mutation testing to explore the strengths and weaknesses of the existing automated tests.  Mutation testing intentionally alters the code by reversing the values of logic and removing method calls.  The changes are then tested with the plugin test automation to see which code changes cause a test failure and which are undetected.

Mutation testing is disabled by default.  Use `mvn org.pitest:pitest-maven:mutationCoverage` to perform mutation testing and generate a report.
