### PR TITLE
Test with Red Hat 8.5 release file

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi8/ubi/8.5/redhat-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi8/ubi/8.5/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux release 8.5 (Ootpa)


### PR DESCRIPTION
## Test with Red Hat 8.5 release file

Release file was included in tests for Red Hat Enterprise Linux 8.4 but was not included for Red Hat Enterprise Linux 8.5.  Fix that omission.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test
