### PR TITLE
Add Red Hat Enterprise Linux test data

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -71,6 +71,7 @@ public class PlatformDetailsTaskTest {
                             is("openSUSE"),
                             is("OracleServer"),
                             is("Raspbian"),
+                            is("RedHatEnterprise"),
                             is("SUSE"),
                             is("Ubuntu")));
             // Yes, this is a dirty trick to detect the hardware architecture on some JVM's


### PR DESCRIPTION
## Add Red Hat Enterprise Linux test data

Red Hat Enterprise Linux was missing from one of the tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
