### PR TITLE
Enable OpenClover coverage reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,12 @@ which verify your change.
 
 ## Code Coverage
 
-Code coverage reporting is available as a maven target.
+[JaCoCo code coverage](https://www.jacoco.org/jacoco/) reporting is available as a maven target and can be displayed by the [Jenkins warnings next generation plugin](https://plugins.jenkins.io/warnings-ng/).
 Please try to improve code coverage with tests when you submit.
-* `mvn -P enable-jacoco clean install jacoco:report` to report code coverage
+* `mvn -P enable-jacoco clean install jacoco:report` to report code coverage with JaCoCo.
+
+[OpenClover code coverage](https://openclover.org/) reporting is available as a maven target and can be displayed by the [Jenkins clover plugin](https://plugins.jenkins.io/clover/).
+* `mvn clover:setup clover:instrument test clover:clover` to report code coverage with OpenClover.
 
 Please don't introduce new spotbugs output.
 * `mvn spotbugs:check` to analyze project using [Spotbugs](https://spotbugs.github.io)

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,18 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.openclover</groupId>
+        <artifactId>clover-maven-plugin</artifactId>
+        <version>4.4.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>instrument</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.5.3.0</version>


### PR DESCRIPTION
## Enable optional OpenClover coverage reporting

OpenClover provides coverage reporting that is similar to other coverage reporting tools, like JaCoCo.  In addition, it provides a test optimization facility that may avoid unmodified tests when evaluating a pull request or other change.

Tests in this plugin are fast enough that the test avoidance does not matter.  Tests in other plugins might benefit significantly from test avoidance, if it is accurate enough.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
