### PR TITLE
Move forkCount to a maven profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Run pre-commit checks on all files:
 $ pre-commit run --all-files
 ```
 
-## Maintaing automated tests
+## Maintaining automated tests
 
 Automated tests are run as part of the `verify` phase.
 Automated tests in the `continuous-integration` profile are run with multiple Java virtual machines, depending on the number of available processor cores.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ $ pre-commit run --all-files
 
 ## Maintaing automated tests
 
+Automated tests are run as part of the `verify` phase.
+Automated tests in the `continuous-integration` profile are run with multiple Java virtual machines, depending on the number of available processor cores.
+Run automated tests with multiple Java virtual machines in a development with the command:
+
+```
+$ mvn clean -DforkCount=1C verify
+```
+
 Test data for automated tests is extracted from Docker images defined in subdirectories of `src/test/resources/org/jvnet/hudson/plugins/platformlabeler`.
 The subdirectory name is used as an index into a map that defines the expected value of the operating system name.
 

--- a/pom.xml
+++ b/pom.xml
@@ -279,42 +279,25 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>0.8C</forkCount>
-          <reuseForks>true</reuseForks>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.pitest</groupId>
         <artifactId>pitest-maven</artifactId>
         <version>1.7.3</version>
       </plugin>
     </plugins>
   </build>
-  <!-- <profiles> -->
-  <!--   <profile> -->
-  <!--     <id>pitest</id> -->
-  <!--     <build> -->
-  <!--       <plugins> -->
-  <!--         <plugin> -->
-  <!--           <groupId>org.pitest</groupId> -->
-  <!--           <artifactId>pitest-maven</artifactId> -->
-  <!--           <version>1.7.3</version> -->
-  <!--           <configuration> -->
-  <!--             <executions> -->
-  <!--               <execution> -->
-  <!--                 <id>pitest</id> -->
-  <!--                 <phase>test</phase> -->
-  <!--                 <goals> -->
-  <!--                   <goal>mutationCoverage</goal> -->
-  <!--                 </goals> -->
-  <!--               </execution> -->
-  <!--             </executions> -->
-  <!--           </configuration> -->
-  <!--         </plugin> -->
-  <!--       </plugins> -->
-  <!--     </build> -->
-  <!--   </profile> -->
-  <!-- </profiles> -->
+
+  <profiles>
+    <profile>
+      <id>continuous-integration</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- Fork a JVM per core for automated tests on continuous integration servers -->
+        <forkCount>1C</forkCount>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Move forkCount to a maven profile

James Nord noted that setting the surefire plugin forkCount in the configuration of all builds may be a disadvantage for developers with multi-core laptops that they do not want to heavily load with tests when running a plugin build.

He suggested a profile for continuous integration environments that is not enabled for the typical developer experience.

- Move forkCount to a CI profile
- Fix spelling error in heading

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Dependency update
