### PR TITLE
Require Jenkins 2.303.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.289.1', '2.303.1', '2.303.2', '2.316', '2.317', '2.318' ]
+def testJenkinsVersions = [ '2.303.3', '2.319.1', '2.319.2', '2.331', '2.332' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.303.3</jenkins.version>
     <java.level>8</java.level>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
@@ -56,7 +56,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
+        <artifactId>bom-2.303.x</artifactId>
         <version>1135.va_4eeca_ea_21c1</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.303.3 or later

Jenkins 2.303.3 is one of the recommended base versions.

- Test with 2.303.3 and later in test environment
- Require Jenkins 2.303.3

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
