### PR TITLE
Test 2.332.1 and recent weekly releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,8 @@
 
 import java.util.Collections
 
-// Valid Jenkins versions for test
-def testJenkinsVersions = [ '2.303.3', '2.319.1', '2.319.2', '2.331', '2.332' ]
+// Valid Jenkins versions for markwaite.net test
+def testJenkinsVersions = [ '2.303.3', '2.319.1', '2.319.2', '2.319.3', '2.332.1', '2.334', '2.335', '2.337', '2.338' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations


### PR DESCRIPTION
## Test Jenkins 2.332.1 and recent weekly releases

Update the testing configuration to include the most recent Jenkins LTS release and the recent weekly releases.  Significant changes in both those release streams.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- ~~I have referenced the Jira issue related to my changes in one or more commit messages~~
- ~~I have added tests that verify my changes~~
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
