### PR TITLE
Update test OS versions and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Linux Mint 19.3            | `LinuxMint`        | `19.3`         | `amd64`      |
 | Linux Mint 20              | `Linuxmint`        | `20`           | `amd64`      |
 | Linux Mint 20.3            | `Linuxmint`        | `20.3`         | `amd64`      |
-| openSUSE Leap              | `openSUSE`         | `15.4`         | `amd64`      |
+| openSUSE Leap              | `openSUSE`         | `15.3`         | `amd64`      |
 | Oracle Linux 7             | `OracleServer`     | `7.9`          | `amd64`      |
 | Oracle Linux 8             | `OracleServer`     | `8.5`          | `amd64`      |
 | Red Hat Enterprise Linux 7 | `RedHatEnterprise` | `7.9`          | `amd64`      |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Fedora 33                  | `Fedora`           | `33`           | `amd64`      |
 | Fedora 34                  | `Fedora`           | `34`           | `amd64`      |
 | Fedora 35                  | `Fedora`           | `35`           | `amd64`      |
-| FreeBSD 12                 | `freebsd`          | `12.2-RELEASE` | `amd64`      |
+| FreeBSD 12                 | `freebsd`          | `12.3-RELEASE` | `amd64`      |
 | FreeBSD 13                 | `freebsd`          | `13.0-RELEASE` | `amd64`      |
 | Linux Mint 19.3            | `LinuxMint`        | `19.3`         | `amd64`      |
 | Linux Mint 20              | `Linuxmint`        | `20`           | `amd64`      |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Platform                   | OS Name            | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
 | Alibaba Linux 3            | `AlibabaCloud`     | `3`            | `amd64`      |
-| Alpine 3.12                | `Alpine`           | `3.12.9`       | `amd64`      |
+| Alpine 3.12                | `Alpine`           | `3.12.10`      | `amd64`      |
 | Alpine 3.13                | `Alpine`           | `3.13.7`       | `amd64`      |
 | Alpine 3.14                | `Alpine`           | `3.14.3`       | `amd64`      |
 | Alpine 3.15                | `Alpine`           | `3.15.0`       | `amd64`      |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alibaba Linux 3            | `AlibabaCloud`     | `3`            | `amd64`      |
 | Alpine 3.12                | `Alpine`           | `3.12.10`      | `amd64`      |
 | Alpine 3.13                | `Alpine`           | `3.13.8`       | `amd64`      |
-| Alpine 3.14                | `Alpine`           | `3.14.3`       | `amd64`      |
+| Alpine 3.14                | `Alpine`           | `3.14.4`       | `amd64`      |
 | Alpine 3.15                | `Alpine`           | `3.15.0`       | `amd64`      |
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      |
 | CentOS 7                   | `CentOS`           | `7.9.2009`     | `amd64`      |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alpine 3.12                | `Alpine`           | `3.12.10`      | `amd64`      |
 | Alpine 3.13                | `Alpine`           | `3.13.8`       | `amd64`      |
 | Alpine 3.14                | `Alpine`           | `3.14.4`       | `amd64`      |
-| Alpine 3.15                | `Alpine`           | `3.15.0`       | `amd64`      |
+| Alpine 3.15                | `Alpine`           | `3.15.1`       | `amd64`      |
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      |
 | CentOS 7                   | `CentOS`           | `7.9.2009`     | `amd64`      |
 | CentOS 8                   | `CentOS`           | `8.4.2105`     | `amd64`      |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | -------------------------- | ------------------ | -------------- | ------------ |
 | Alibaba Linux 3            | `AlibabaCloud`     | `3`            | `amd64`      |
 | Alpine 3.12                | `Alpine`           | `3.12.10`      | `amd64`      |
-| Alpine 3.13                | `Alpine`           | `3.13.7`       | `amd64`      |
+| Alpine 3.13                | `Alpine`           | `3.13.8`       | `amd64`      |
 | Alpine 3.14                | `Alpine`           | `3.14.3`       | `amd64`      |
 | Alpine 3.15                | `Alpine`           | `3.15.0`       | `amd64`      |
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Platform                   | OS Name            | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
 | Ubuntu 18                  | `Ubuntu`           | `18.04`        | `s390x`      |
+| Ubuntu 20                  | `Ubuntu`           | `20.04`        | `s390x`      |
 
 ## IBM PowerPC 64 little endian (ppc64le)
 

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.12.10

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.12.9
+VERSION_ID=3.12.10
 PRETTY_NAME="Alpine Linux v3.12"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.9/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.9/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.12.9

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.7/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.7/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.13.7

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.8/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.8/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.13.8

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.8/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.13.8/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.13.7
+VERSION_ID=3.13.8
 PRETTY_NAME="Alpine Linux v3.13"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.3/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.3/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.14.3

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.4/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.4/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.14.4

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.4/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.14.4/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.14.3
+VERSION_ID=3.14.4
 PRETTY_NAME="Alpine Linux v3.14"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"


### PR DESCRIPTION
## Update operating system test images and documentation

- Test Alpine 3.12.10, not 3.12.9
- Test with Alpine 3.13.8, not 3.13.7
- Test with Alpine 3.14.4, not 3.14.3
- Doc Alpine 3.15.1
- Update FreeBSD 12 version in README
- OpenSUSE 15.4 has not released yet
- Add s390x Ubuntu 20.04

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test and documentation update
