### PR TITLE
Fixup messages path for Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,3 @@
 files:
-  - source: src/main/resources/**/*.html
-    translation: src/main/resources/**/%original_file_name%_%two_letters_code%.%file_extension%
+  - source: /src/main/resources/**/*.html
+    translation: /src/main/resources/**/%file_name%_%two_letters_code%.html


### PR DESCRIPTION
Heyo @MarkEWaite, quick fixup for our recent docs office session.
I forgot to mention that `original_file_name` is the file name + extension, but we need the truncated version and use the language code of the corresponding language.

See [here](https://support.crowdin.com/configuration-file/#placeholders) for a description what each placeholder does.

I paused the GitHub integration until we got this PR merged.