### PR TITLE
Don't count source files twice

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,5 @@
 files:
   - source: /src/main/resources/**/*.html
+    ignore:
+      - /src/main/resources/**/%file_name%_%two_letters_code%.html
     translation: /src/main/resources/**/%file_name%_%two_letters_code%.html


### PR DESCRIPTION
In Jenkins, the translated files go in the same folder like the source files, therefore we have to exclude them in the crowdin.yml to not be counted as source files.

Additionally, I would vouch for automatically deleting merged branches, to not end up with stale crowdin branches, which are behind master, like at the moment, which requires manual deletion of that branch.

![](https://i.imgur.com/BVOhpHQ.png)
Simply ticking that in https://github.com/jenkinsci/platformlabeler-plugin/settings takes care of it.
