### PR TITLE
require 2.319.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for markwaite.net test
-def testJenkinsVersions = [ '2.303.3', '2.319.1', '2.319.2', '2.319.3', '2.332.1', '2.334', '2.335', '2.337', '2.338' ]
+def testJenkinsVersions = [ '2.319.3', '2.332.1', '2.335', '2.337', '2.338', '2.339', '2.340', '2.341' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build recommended configurations

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
   <packaging>hpi</packaging>
 
   <name>Jenkins Platform Labeler Plugin</name>
-  <description>Labels agents based on their operating system (platform) version and architecture</description>
   <url>https://github.com/jenkinsci/platformlabeler-plugin/</url>
   <inceptionYear>2009</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.303.3</jenkins.version>
+    <jenkins.version>2.319.3</jenkins.version>
     <java.level>8</java.level>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
@@ -55,7 +55,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.303.x</artifactId>
+        <artifactId>bom-2.319.x</artifactId>
         <version>1210.vcd41f6657f03</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
- Remove description from pom.xml
- Require Jenkins 2.319.3 or later
