### PR TITLE
Add Alma Linux 8.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,17 @@ updates:
     versions: [">= 0"]
 
 - package-ecosystem: docker
+  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/almalinux/8.5"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  target-branch: master
+  reviewers:
+  - MarkEWaite
+  labels:
+  - skip-changelog
+
+- package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.2"
   schedule:
     interval: weekly

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Platform                   | OS Name            | Version        | Architecture |
 | -------------------------- | ------------------ | -------------- | ------------ |
 | Alibaba Linux 3            | `AlibabaCloud`     | `3`            | `amd64`      |
+| Alma Linux 8               | `AlmaLinux`        | `8.5`          | `amd64`      |
 | Alpine 3.12                | `Alpine`           | `3.12.10`      | `amd64`      | // EOL: 01 May 2022
 | Alpine 3.13                | `Alpine`           | `3.13.8`       | `amd64`      |
 | Alpine 3.14                | `Alpine`           | `3.14.4`       | `amd64`      |

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -324,6 +324,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
 
     static {
         PREFERRED_LINUX_OS_NAMES.put("alinux", "AlibabaCloud");
+        PREFERRED_LINUX_OS_NAMES.put("almalinux", "Alma");
         PREFERRED_LINUX_OS_NAMES.put("alpine", "Alpine");
         PREFERRED_LINUX_OS_NAMES.put("amzn", "Amazon");
         PREFERRED_LINUX_OS_NAMES.put("centos", "CentOS");

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -70,8 +70,11 @@ public class PlatformDetailsTaskLsbReleaseTest {
     }
 
     private static String computeExpectedName(String filename) {
-        if (filename.contains("alinux")) {
+        if (filename.contains("alinux") && !filename.contains("almalinux")) {
             return "AlibabaCloud";
+        }
+        if (filename.contains("almalinux")) {
+            return "AlmaLinux";
         }
         if (filename.contains("amzn")) {
             if (filename.contains("amzn/2018.03")) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -94,8 +94,11 @@ public class PlatformDetailsTaskReleaseTest {
     }
 
     private static String computeExpectedName(String filename) {
-        if (filename.contains("alinux")) {
+        if (filename.contains("alinux") && !filename.contains("almalinux")) {
             return "AlibabaCloud";
+        }
+        if (filename.contains("almalinux")) {
+            return "Alma";
         }
         if (filename.contains("amzn")) {
             return "Amazon";

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -63,6 +63,7 @@ public class PlatformDetailsTaskTest {
                     name,
                     anyOf(
                             is("AlibabaCloud"),
+                            is("Alma"),
                             is("Alpine"),
                             is("Amazon"),
                             is("AmazonAMI"),

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/almalinux/8.5/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/almalinux/8.5/Dockerfile
@@ -1,0 +1,2 @@
+FROM almalinux:8.5-20220306
+RUN yum install -y redhat-lsb-core

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/almalinux/8.5/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/almalinux/8.5/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:	:core-4.1-amd64:core-4.1-noarch
+Distributor ID:	AlmaLinux
+Description:	AlmaLinux release 8.5 (Arctic Sphynx)
+Release:	8.5
+Codename:	ArcticSphynx

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/almalinux/8.5/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/almalinux/8.5/os-release
@@ -1,0 +1,16 @@
+NAME="AlmaLinux"
+VERSION="8.5 (Arctic Sphynx)"
+ID="almalinux"
+ID_LIKE="rhel centos fedora"
+VERSION_ID="8.5"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="AlmaLinux 8.5 (Arctic Sphynx)"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:almalinux:almalinux:8::baseos"
+HOME_URL="https://almalinux.org/"
+DOCUMENTATION_URL="https://wiki.almalinux.org/"
+BUG_REPORT_URL="https://bugs.almalinux.org/"
+
+ALMALINUX_MANTISBT_PROJECT="AlmaLinux-8"
+ALMALINUX_MANTISBT_PROJECT_VERSION="8.5"
+


### PR DESCRIPTION
Configure dependabot for Alma Linux.

Add docs for Alma Linux.

Adapt tests for Alma Linux, including test data and data generation.
