### PR TITLE
Test Java 17 in addition to Java 11 and Java 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,22 +3,27 @@
 import java.util.Collections
 
 // Valid Jenkins versions for markwaite.net test
-def testJenkinsVersions = [ '2.319.3', '2.332.1', '2.335', '2.337', '2.338', '2.339', '2.340', '2.341' ]
+def testJenkinsVersions = [ '2.319.3', '2.332.1', '2.332.2', '2.335', '2.337', '2.338', '2.339', '2.340', '2.341', '2.342' ]
 Collections.shuffle(testJenkinsVersions)
 
-// build recommended configurations
-subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: testJenkinsVersions[0], javaLevel: '8' ],
+// build with randomized Jenkins versions
+subsetConfiguration = [ [ jdk: '8',  platform: 'windows', jenkins: testJenkinsVersions[0] ],
 
                         // Intel Linux is labeled as 'linux' for legacy reasons
-                        [ jdk: '8',  platform: 'linux',   jenkins: testJenkinsVersions[1], javaLevel: '8' ],
-                        [ jdk: '11', platform: 'linux',   jenkins: testJenkinsVersions[2], javaLevel: '8' ],
+                        [ jdk: '8',  platform: 'linux',   jenkins: testJenkinsVersions[1] ],
+                        [ jdk: '11', platform: 'linux',   jenkins: testJenkinsVersions[2] ],
+                        [ jdk: '17', platform: 'linux',   jenkins: '2.342' ],
 
                         // ARM label is Linux also
-                        [ jdk: '11', platform: 'arm64',   jenkins: testJenkinsVersions[3], javaLevel: '8' ],
+                        [ jdk: '11', platform: 'arm64',   jenkins: testJenkinsVersions[3] ],
+                        [ jdk: '17', platform: 'arm64',   jenkins: '2.342' ],
 
                         // PowerPC 64 and s390x labels are also Linux
-                        [ jdk: '8',  platform: 'ppc64le', jenkins: testJenkinsVersions[4], javaLevel: '8' ],
-                        [ jdk: '11', platform: 's390x',   jenkins: testJenkinsVersions[5], javaLevel: '8' ],
+                        [ jdk: '8',  platform: 'ppc64le', jenkins: testJenkinsVersions[4] ],
+                        [ jdk: '11', platform: 'ppc64le', jenkins: testJenkinsVersions[5] ],
+                        [ jdk: '17', platform: 'ppc64le', jenkins: testJenkinsVersions[6] ],
+                        [ jdk: '11', platform: 's390x',   jenkins: testJenkinsVersions[7] ],
+                        [ jdk: '17', platform: 's390x',   jenkins: testJenkinsVersions[8] ],
                       ]
 
 if (env.JENKINS_URL.contains('markwaite.net')) {
@@ -28,6 +33,7 @@ if (env.JENKINS_URL.contains('markwaite.net')) {
     // Use simple buildPlugin elsewhere
     buildPlugin(failfast: false,
         configurations: [
+            [platform: 'linux',   jdk: '17', jenkins: '2.342'],
             [platform: 'linux',   jdk: '11'],
             [platform: 'windows', jdk:  '8']
         ]


### PR DESCRIPTION
## Test Java 17 in addition to Java 11 and Java 8

https://groups.google.com/g/jenkinsci-dev/c/ZHO3i7oaAfU/m/QdlzD8G2BwAJ describes the request to include Java 17 testing.

Test Java 17 on amd64, arm64, ppc64le, & s390x when inside markwaite.net.

When running elsewhere, test linux and windows with Java 17, 11, and 8.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Platform update
