### PR TITLE
Check Alpine 3.15.3 for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
   - skip-changelog
 
 - package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.2"
+  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.3"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alpine 3.12                | `Alpine`           | `3.12.10`      | `amd64`      | // EOL: 01 May 2022
 | Alpine 3.13                | `Alpine`           | `3.13.8`       | `amd64`      |
 | Alpine 3.14                | `Alpine`           | `3.14.4`       | `amd64`      |
-| Alpine 3.15                | `Alpine`           | `3.15.2`       | `amd64`      |
+| Alpine 3.15                | `Alpine`           | `3.15.3`       | `amd64`      |
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      |
 | CentOS 7                   | `CentOS`           | `7.9.2009`     | `amd64`      |
 | CentOS 8                   | `CentOS`           | `8.4.2105`     | `amd64`      |


### PR DESCRIPTION
## Check Alpine 3.15.3 for updates

Alpine 3.15.2 is no longer the target release.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
