### PR TITLE
Remove Alpine 3.12 - end of life

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Labels commonly include operating system name, version, architecture, and Window
 | -------------------------- | ------------------ | -------------- | ------------ |
 | Alibaba Linux 3            | `AlibabaCloud`     | `3`            | `amd64`      |
 | Alma Linux 8               | `AlmaLinux`        | `8.5`          | `amd64`      |
-| Alpine 3.12                | `Alpine`           | `3.12.10`      | `amd64`      | // EOL: 01 May 2022
 | Alpine 3.13                | `Alpine`           | `3.13.8`       | `amd64`      |
 | Alpine 3.14                | `Alpine`           | `3.14.4`       | `amd64`      |
 | Alpine 3.15                | `Alpine`           | `3.15.4`       | `amd64`      |

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.12.10

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.12.10/os-release
@@ -1,6 +1,0 @@
-NAME="Alpine Linux"
-ID=alpine
-VERSION_ID=3.12.10
-PRETTY_NAME="Alpine Linux v3.12"
-HOME_URL="https://alpinelinux.org/"
-BUG_REPORT_URL="https://bugs.alpinelinux.org/"


### PR DESCRIPTION
## Remove Alpine 3.12 - unsupported

Alpine 3.12 reached end of life May 1, 2022. Remove from the documentation and the tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
