### PR TITLE
Add Ubuntu 22.04 test data and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -133,3 +133,17 @@ updates:
   - MarkEWaite
   labels:
   - skip-changelog
+  ignore:
+    - dependency-name: "Dockerfile"
+      versions: [">= 22.0.0"]
+
+- package-ecosystem: docker
+  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/22.04"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  target-branch: master
+  reviewers:
+  - MarkEWaite
+  labels:
+  - skip-changelog

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Ubuntu 18                  | `Ubuntu`           | `18.04`        | `amd64`      |
 | Ubuntu 20                  | `Ubuntu`           | `20.04`        | `amd64`      |
 | Ubuntu 21                  | `Ubuntu`           | `21.10`        | `amd64`      | // EOL: 31 Jul 2022
+| Ubuntu 22                  | `Ubuntu`           | `22.04`        | `amd64`      |
 | Windows 10                 | `windows`          | `10.0`         | `amd64`      |
 
 ## ARM 64 bit (aarch64)

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/22.04/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/22.04/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu:jammy-20220428
+RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/22.04/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/22.04/lsb_release-a
@@ -1,0 +1,5 @@
+No LSB modules are available.
+Distributor ID:	Ubuntu
+Description:	Ubuntu 22.04 LTS
+Release:	22.04
+Codename:	jammy

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/22.04/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/ubuntu/22.04/os-release
@@ -1,0 +1,12 @@
+NAME="Ubuntu"
+VERSION="22.04 LTS (Jammy Jellyfish)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 22.04 LTS"
+VERSION_ID="22.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=jammy
+UBUNTU_CODENAME=jammy


### PR DESCRIPTION
## Add Ubuntu 22.04 test data and docs

Add Ubuntu 22.04 as the latest release of Ubuntu.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
