### PR TITLE
Add Oracle Linux 8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Linux Mint 20.3            | `Linuxmint`        | `20.3`         | `amd64`      | // EOL:    Apr 2025
 | openSUSE Leap              | `openSUSE`         | `15.3`         | `amd64`      | // EOL: 30 Nov 2022
 | Oracle Linux 7             | `OracleServer`     | `7.9`          | `amd64`      | // EOL: 30 Jun 2024
-| Oracle Linux 8             | `OracleServer`     | `8.5`          | `amd64`      | // EOL: 31 May 2029
+| Oracle Linux 8             | `OracleServer`     | `8.6`          | `amd64`      | // EOL: 31 May 2029
 | Red Hat Enterprise Linux 7 | `RedHatEnterprise` | `7.9`          | `amd64`      | // EOL: 30 Jun 2024
 | Red Hat Enterprise Linux 8 | `RedHatEnterprise` | `8.6`          | `amd64`      | // EOL: 31 May 2029
 | Scientific 7               | `Scientific`       | `7.9`          | `amd64`      | // EOL: 30 Jun 2024

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.6/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.6/Dockerfile
@@ -1,0 +1,5 @@
+# https://github.com/oracle/container-images/pkgs/container/oraclelinux
+# recommends 8-slim but this image chooses specifically to use 8.6 because
+# it is more precise.
+FROM ghcr.io/oracle/oraclelinux:8.6
+RUN dnf install -y redhat-lsb-core

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.6/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.6/lsb_release-a
@@ -1,0 +1,5 @@
+LSB Version:	:core-4.1-amd64:core-4.1-noarch
+Distributor ID:	OracleServer
+Description:	Oracle Linux Server release 8.6
+Release:	8.6
+Codename:	n/a

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.6/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/oraclelinux/8.6/os-release
@@ -1,0 +1,18 @@
+NAME="Oracle Linux Server"
+VERSION="8.6"
+ID="ol"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="8.6"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Oracle Linux Server 8.6"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:8:6:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
+ORACLE_BUGZILLA_PRODUCT_VERSION=8.6
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=8.6


### PR DESCRIPTION
## Add Oracle Linux 8.6 test data

Oracle Linux 8.6 is now available.  Add test data for it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
