### PR TITLE
Revert "Simplify JUnit 5 dependency"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <!-- No API's intended to be used, none should be called from outside. -->
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
+    <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <pmdVersion>6.47.0</pmdVersion>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.failOnError>true</spotbugs.failOnError>
@@ -94,8 +95,27 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>5.8.2</version>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <type>jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Run JUnit 4 and JUnit 5 tests

Do not skip JUnit 4 test discovery by the Maven surefire plugin.

When I simplified the JUnit Jupiter dependencies in the pom file, I somehow also stopped the discovery of JUnit 4 based tests, like the InjectedTest and the NodeLabelCacheTest.

Will need more investigation to find the correct way to find and run both JUnit 4 and JUnit 5 tests from a Jenkins plugin.

Thanks to the coverage report on ci.jenkins.io for showing a clear and visible loss of test coverage.

This reverts commit 88aadbb02d5e58d37c8649cf06d7f62e8d5e2deb.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
