### PR TITLE
Use latest Debian buster test data

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/10/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/10/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:buster-20220622-slim
+FROM debian:buster-20220711-slim
 RUN apt-get update && apt-get install -y lsb-release


### PR DESCRIPTION
## Use latest Debian test data

Debian Buster needed an update to the most recent container version.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Test

/label test
