### PR TITLE
Require Jenkins 2.332.4 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For example:
 
 The types of labels can be configured globally and per agent with the 'Automatic Platform Labels' setting.
 
-To define the labels for an agent, activate 'Automatic Platform Labels' in the Node Properties section and select the desired labels.
+To reduce the set of labels defined for an agent, activate 'Automatic Platform Labels' in the Node Properties section and select the desired label types.
 
 ## Report an Issue
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-    <jenkins.version>2.319.3</jenkins.version>
+    <jenkins.version>2.332.4</jenkins.version>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
     <!-- No API's intended to be used, none should be called from outside. -->
@@ -53,7 +53,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
+        <artifactId>bom-2.332.x</artifactId>
         <version>1556.vfc6a_f216e3c6</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.332.4 or newer

Security advisory has been published for Jenkins 2.332.3 and older.  No benefit for users to support releases with known security issues.  If they need an older release of Jenkins, they can also choose to use an older release of the plugin.

Increasing the minimum Jenkins version also more accurately describes the range of versions that are tested.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
