### PR TITLE
enable Gitpod prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,3 +14,13 @@ vscode:
     - vscjava.vscode-java-dependency
     - vscjava.vscode-java-test
     - vscjava.vscode-maven
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: false
+    addComment: false
+    addBadge: true


### PR DESCRIPTION
This PR updates the Gitpod prebuild configuration.

Note that this feature might require some further fine tuning.
