### PR TITLE
Remove `junit-bom` from managed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>5.9.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
This is part of the plugin parent POM as of https://github.com/jenkinsci/plugin-pom/pull/560.