### PR TITLE
End support for ppc64le

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,9 +18,7 @@ subsetConfiguration = [ [ jdk: '11',  platform: 'windows', jenkins: testJenkinsV
                         [ jdk: '11', platform: 'arm64',   jenkins: testJenkinsVersions[3] ],
                         [ jdk: '17', platform: 'arm64',   jenkins: '2.361' ],
 
-                        // PowerPC 64 and s390x labels are also Linux
-                        [ jdk: '11', platform: 'ppc64le', jenkins: testJenkinsVersions[4] ],
-                        [ jdk: '17', platform: 'ppc64le', jenkins: testJenkinsVersions[5] ],
+                        // s390x label is also Linux
                         [ jdk: '11', platform: 's390x',   jenkins: testJenkinsVersions[6] ],
                         [ jdk: '17', platform: 's390x',   jenkins: testJenkinsVersions[7] ],
                       ]

--- a/README.md
+++ b/README.md
@@ -70,12 +70,6 @@ Labels commonly include operating system name, version, architecture, and Window
 | Ubuntu 18                  | `Ubuntu`           | `18.04`        | `s390x`      | // EOL: 30 Apr 2023
 | Ubuntu 20                  | `Ubuntu`           | `20.04`        | `s390x`      | // EOL: 30 Apr 2025
 
-## IBM PowerPC 64 little endian (ppc64le)
-
-| Platform                   | OS Name            | Version        | Architecture |
-| -------------------------- | ------------------ | -------------- | ------------ |
-| Ubuntu 18                  | `Ubuntu`           | `18.04`        | `ppc64le`    | // EOL: 30 Apr 2023
-
 On Windows computers, the plugin assigns a label based on the Windows feature update.
 Feature update labels use a two digit year and a two digit month representation.
 Common values for Windows feature update are `1809`, `1903`, `2009`, and `2109`.


### PR DESCRIPTION
## End support for PowerPC 64

PowerPC 64 test machines are no longer available, so PowerPC 64 support is being removed from the plugin.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation and platform support
