### PR TITLE
[JENKINS-69814] Assign Debian unstable a valid release

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -260,6 +260,15 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
                 /* Try reading it from a different location */
                 computedVersion = getDebianVersionIdentifier();
             }
+            /* Debian unstable changed the lsb_release Release: value to "n/a"
+             * in Oct 2022.  Retain the name "unstable" instead of calling the
+             * release "n/a".  Embedding a "/" in the label will cause problems
+             * like those described in JENKINS-64324.
+             */
+            if (equalsIgnoreCase(computedName, "debian")
+                    && equalsIgnoreCase(computedVersion, "n/a")) {
+                computedVersion = "unstable";
+            }
             /* JENKINS-64324 notes that labels with '/' break various Jenkins components */
             /* For example, Debian testing reports its version as "testing/unstable" */
             /* Take the portion of the version string that precedes the '/' character */

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -62,11 +62,12 @@ public class PlatformDetailsTaskLsbReleaseTest {
         PlatformDetails result = details.computeLabels("amd64", "linux", "xyzzy-abc", release);
         assertThat(result.getArchitecture(), is(expectedArch));
         assertThat(result.getName(), is(expectedName));
+        assertThat(result.getVersion(), is(expectedVersion));
         assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
+        assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
         assertThat(
                 result.getArchitectureNameVersion(),
                 is(expectedArch + "-" + expectedName + "-" + expectedVersion));
-        assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
     }
 
     private static String computeExpectedName(String filename) {

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
@@ -1,5 +1,6 @@
 PRETTY_NAME="Debian GNU/Linux bookworm/sid"
 NAME="Debian GNU/Linux"
+VERSION_CODENAME=bookworm
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
@@ -1,5 +1,5 @@
 No LSB modules are available.
 Distributor ID:	Debian
 Description:	Debian GNU/Linux bookworm/sid
-Release:	unstable
-Codename:	sid
+Release:	n/a
+Codename:	bookworm

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
@@ -1,5 +1,6 @@
 PRETTY_NAME="Debian GNU/Linux bookworm/sid"
 NAME="Debian GNU/Linux"
+VERSION_CODENAME=bookworm
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"


### PR DESCRIPTION
## [JENKINS-69814](https://issues.jenkins.io/browse/JENKINS-69814) Assign Debian unstable a valid release

Assign Debian unstable the release value 'unstable' when the release value is reported by the `lsb_release` command as `n/a'.

Debian unstable modified the lsb_release output in the Oct 2022 Docker container image to report "n/a" as the release value.  That is a sensible and reasonable value, but it collides with the desire of the platform labeler plugin to not assign labels that contain "/" and it breaks with what people might expect for compatibility with previous behavior.

- Debian unstable lsb_release has changed release and codename
- Debian testing and unstable have new codename
- More assertions for the lsb_release test
- [JENKINS-69814] Assign Debian unstable a valid release

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing performed

- [x] Confirmed that `Debian-n` is the label automatically assigned for an agent started from the `debain:unstable-20221004` image with the current release of the platform labeler plugin
- [x] Confirmed that the pull request built release assigns the label `Debian-unstable` to that agent