### PR TITLE
[JENKINS-69971] Assign Debian testing label correctly

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -32,10 +32,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /** Linux standard base release class. Provides distributor ID and release. */
 public class LsbRelease implements PlatformDetailsRelease {
@@ -55,7 +58,12 @@ public class LsbRelease implements PlatformDetailsRelease {
         }
         this.distributorId =
                 newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-        this.release = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        String guessedRelease =
+                newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        if (guessedRelease.equals("n/a")) {
+            guessedRelease = guessDebianRelease(guessedRelease);
+        }
+        this.release = guessedRelease;
     }
 
     /** Assign distributor ID and release. Package protected for tests. */
@@ -72,7 +80,12 @@ public class LsbRelease implements PlatformDetailsRelease {
         }
         this.distributorId =
                 newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-        this.release = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        String guessedRelease =
+                newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        if (guessedRelease.equals("n/a")) {
+            guessedRelease = guessDebianReleaseFromFile(lsbReleaseFile);
+        }
+        this.release = guessedRelease;
     }
 
     private void readLsbReleaseOutput(InputStream inputStream, Map<String, String> newProps)
@@ -84,6 +97,70 @@ public class LsbRelease implements PlatformDetailsRelease {
                     .map(line -> line.split(":", 2))
                     .forEach(parts -> newProps.put(parts[0], parts[1].trim()));
         }
+    }
+
+    /*
+     * In the test environment, the intended Debian version is encoded
+     * in the path to the file.  If a file was provided with test
+     * data, then the path of that file resolves the question whether
+     * the ambiguous Debian version is testing or unstable.
+     */
+    private String guessDebianReleaseFromFile(@NonNull File testData) {
+        String unstableDir = File.separator + "unstable" + File.separator;
+        return testData.getPath().contains(unstableDir) ? "unstable" : "testing";
+    }
+
+    /*
+     * Debian testing has periods during its lifecycle when the
+     * lsb_release command cannot distinguish between testing and
+     * unstable.  That is an accepted condition for the Debian
+     * developers.
+     *
+     * See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845651
+     * for more details.
+     *
+     * When in that state, the apt-cache command can be used to
+     * determine the Debian release that is running.
+     *
+     * The base-files package is used to query the apt-cache policy
+     * because it is required for all Debian installations and because
+     * it is the package that provides the /etc/os-release file that
+     * is used elsewhere to determine version information in case the
+     * lsb_release command is not available.
+     */
+    private String guessDebianRelease(@NonNull String defaultValue) {
+        String value = defaultValue;
+        try {
+            Process process = new ProcessBuilder("apt-cache", "policy", "base-files").start();
+            value = readReleaseFromAptCachePolicyOutput(process.getInputStream());
+        } catch (IOException e) {
+            LOGGER.log(Level.FINEST, "apt-cache execution failed", e);
+        }
+        return value;
+    }
+
+    /* Identifying strings in apt-cache policy output that identify
+     * the unstable distribution
+     */
+    private List<String> unstableIdentifiers = Arrays.asList("sid", "unstable");
+
+    /*
+     * If apt-cache output contains one of the unstableIdentifiers,
+     * report it as unstable.  Otherwise report it as testing.
+     */
+    private String readReleaseFromAptCachePolicyOutput(InputStream inputStream) throws IOException {
+        String distribution = "testing";
+        try (BufferedReader reader =
+                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            List<String> results =
+                    reader.lines()
+                            .filter(line -> unstableIdentifiers.stream().anyMatch(line::contains))
+                            .collect(Collectors.toList());
+            if (!results.isEmpty()) {
+                distribution = "unstable";
+            }
+        }
+        return distribution;
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -52,7 +52,9 @@ public class LsbRelease implements PlatformDetailsRelease {
         Map<String, String> newProps = new HashMap<>();
         try {
             Process process = new ProcessBuilder("lsb_release", "-a").start();
-            readLsbReleaseOutput(process.getInputStream(), newProps);
+            try (InputStream stream = process.getInputStream()) {
+                readLsbReleaseOutput(stream, newProps);
+            }
         } catch (IOException e) {
             LOGGER.log(Level.FINEST, "lsb_release execution failed", e);
         }
@@ -132,7 +134,9 @@ public class LsbRelease implements PlatformDetailsRelease {
         String value = defaultValue;
         try {
             Process process = new ProcessBuilder("apt-cache", "policy", "base-files").start();
-            value = readReleaseFromAptCachePolicyOutput(process.getInputStream());
+            try (InputStream stream = process.getInputStream()) {
+                value = readReleaseFromAptCachePolicyOutput(stream);
+            }
         } catch (IOException e) {
             LOGGER.log(Level.FINEST, "apt-cache execution failed", e);
         }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -59,13 +59,13 @@ public class LsbRelease implements PlatformDetailsRelease {
     }
 
     /** Assign distributor ID and release. Package protected for tests. */
-    LsbRelease(String distributorId, String release) {
+    LsbRelease(@NonNull String distributorId, @NonNull String release) {
         this.distributorId = distributorId;
         this.release = release;
     }
 
     /** Read file to assign distributor ID and release. Package protected for tests. */
-    LsbRelease(File lsbReleaseFile) throws IOException {
+    LsbRelease(@NonNull File lsbReleaseFile) throws IOException {
         Map<String, String> newProps = new HashMap<>();
         try (FileInputStream stream = new FileInputStream(lsbReleaseFile)) {
             readLsbReleaseOutput(stream, newProps);

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -131,7 +131,9 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         try {
             Process p = Runtime.getRuntime().exec("/bin/uname -m");
             p.waitFor();
-            return getCanonicalLinuxArchStream(p.getInputStream(), arch);
+            try (InputStream stream = p.getInputStream()) {
+                return getCanonicalLinuxArchStream(stream, arch);
+            }
         } catch (IOException | InterruptedException e) {
             /* Return arch instead of throwing an exception */
             LOGGER.log(Level.FINEST, "uname -m failed", e);
@@ -506,8 +508,8 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         try {
             Process p = Runtime.getRuntime().exec("/bin/freebsd-version -u");
             p.waitFor();
-            try (BufferedReader b =
-                    new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
+            try (InputStream stream = p.getInputStream();
+                    BufferedReader b = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
                 String line = b.readLine();
                 if (line != null) {
                     version = line;

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
@@ -53,7 +53,9 @@ public class WindowsRelease implements PlatformDetailsRelease {
                                     "/v",
                                     "ReleaseId")
                             .start();
-            readWindowsReleaseOutput(process.getInputStream(), newProps);
+            try (InputStream stream = process.getInputStream()) {
+                readWindowsReleaseOutput(stream, newProps);
+            }
         } catch (IOException ignored) {
             // IGNORE
         }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -291,15 +291,16 @@ public class PlatformDetailsTaskTest {
         if (details.getVersion().startsWith(version)) {
             foundValue = details.getVersion();
         }
-        /* If VERSION_ID has the unknown value then handle it as a special
-         * case.  Debian testing does not include a VERSION_ID value in
-         * the /etc/os-release file.  If there is no value for VERSION_ID,
-         * then confirm that the details are for Debian testing and skip
-         * the VERSION_ID assertion.
+        /* If VERSION_ID has the unknown value then handle it as a
+         * special case.  Debian testing and Debian unstable have no
+         * VERSION_ID in the /etc/os-release file.  If there is no
+         * value for VERSION_ID, then confirm that the details are for
+         * Debian testing or unstable and skip the VERSION_ID
+         * assertion.
          */
         if (version.startsWith("unknown")) {
             assertThat(details.getName(), is("Debian"));
-            assertThat(details.getVersion(), is("testing"));
+            assertThat(details.getVersion(), anyOf(is("testing"), is("unstable")));
         } else {
             assertThat(details.getVersion(), anyOf(is(version), is(foundValue)));
         }

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
@@ -1,5 +1,5 @@
 No LSB modules are available.
 Distributor ID:	Debian
 Description:	Debian GNU/Linux bookworm/sid
-Release:	testing
+Release:	n/a
 Codename:	bookworm


### PR DESCRIPTION
## [JENKINS-69971](https://issues.jenkins.io/browse/JENKINS-69971) Assign Debian testing label correctly

Debian testing has periods during its lifecycle when the lsb_release command cannot distinguish between testing and unstable.  That is an accepted condition for the Debian developers.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845651

When in that state, the apt-cache command can be used to determine the Debian release that is running.

The base-files package is used to query the apt-cache policy because it is required for all Debian installations and because it is the package that provides the /etc/os-release file that is used elsewhere to determine version information in case the lsb_release command is not available.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
