### PR TITLE
Add Alpine 3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alpine 3.14                | `Alpine`           | `3.14.8`       | `amd64`      | // EOL: 01 May 2023
 | Alpine 3.15                | `Alpine`           | `3.15.6`       | `amd64`      | // EOL: 01 Nov 2023
 | Alpine 3.16                | `Alpine`           | `3.16.3`       | `amd64`      | // EOL: 01 May 2024
+| Alpine 3.17                | `Alpine`           | `3.17.0`       | `amd64`      | // EOL: 01 Nov 2024
 | Amazon Linux 2             | `Amazon`           | `2`            | `amd64`      | // EOL: 30 Jun 2023
 | Amazon Linux 2022          | `Amazon`           | `2022`         | `amd64`      | // EOL: 31 Dec 2028?
 | CentOS 7                   | `CentOS`           | `7.9.2009`     | `amd64`      | // EOL: 30 Jun 2024

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.17.0/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.17.0/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.17.0

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.17.0/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.17.0/os-release
@@ -1,0 +1,6 @@
+NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.17.0
+PRETTY_NAME="Alpine Linux v3.17"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"


### PR DESCRIPTION
## Add Alpine 3.17.0 test data and documentation

Alpine 3.17.0 was released in November 2022.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Test data and documentation
