### PR TITLE
Require Jenkins 2.361.4 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,13 +27,20 @@ if (env.JENKINS_URL.contains('markwaite.net')) {
     buildPlugin(configurations: subsetConfiguration, failFast: false)
 } else {
     // Use simple buildPlugin elsewhere
-    buildPlugin(failfast: false,
-        // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
-        // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
-        artifactCachingProxyEnabled: true,
-        configurations: [
-            [platform: 'linux',   jdk: '17', jenkins: '2.372'],
-            [platform: 'linux',   jdk: '11']
-        ]
+    /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+    buildPlugin(
+      // Container agents start faster and are easier to administer
+      useContainerAgent: true,
+      // Show failures on all configurations
+      failFast: false,
+      // Opt-in to the Artifact Caching Proxy, to be removed when it will be opt-out.
+      // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
+      artifactCachingProxyEnabled: true,
+      // Test Java 11 with a recent LTS, Java 17 even more recent
+      configurations: [
+        [platform: 'linux',   jdk: '17', jenkins: '2.380'],
+        [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
+        [platform: 'windows', jdk: '11']
+      ]
     )
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.1</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
     <!-- No API's intended to be used, none should be called from outside. -->


### PR DESCRIPTION
## Require Jenkins 2.361.4 or newer.

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ offers Jenkins 2.361.4 as one of the recommended versions.

Java 11 or newer is required for Jenkins 2.361.4 and for the most recent releases of the parent pom.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Dependency update
