### PR TITLE
Improve tests based on PIT evaluation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for markwaite.net test
-def testJenkinsVersions = [ '2.361.1', '2.361.2', '2.361.3', '2.361.4', '2.375.1', '2.379', '2.380', '2.381' ]
+def testJenkinsVersions = [ '2.361.1', '2.361.2', '2.361.3', '2.361.4', '2.375.1', '2.381', '2.382', '2.383', '2.384' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build with randomized Jenkins versions
@@ -38,7 +38,7 @@ if (env.JENKINS_URL.contains('markwaite.net')) {
       artifactCachingProxyEnabled: true,
       // Test Java 11 with a recent LTS, Java 17 even more recent
       configurations: [
-        [platform: 'windows', jdk: '17', jenkins: '2.381'],
+        [platform: 'windows', jdk: '17', jenkins: '2.384'],
         [platform: 'linux', jdk: '11']
       ]
     )

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfigTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfigTest.java
@@ -20,6 +20,7 @@ public class LabelConfigTest {
     private boolean randomIsArchitectureName;
     private boolean randomIsNameVersion;
     private boolean randomIsArchitectureNameVersion;
+    private boolean randomIsWindowsFeatureUpdate;
 
     public LabelConfigTest() {}
 
@@ -33,6 +34,7 @@ public class LabelConfigTest {
         randomIsArchitectureName = random.nextBoolean();
         randomIsNameVersion = random.nextBoolean();
         randomIsArchitectureNameVersion = random.nextBoolean();
+        randomIsWindowsFeatureUpdate = random.nextBoolean();
 
         randomSrcLabelConfig.setArchitecture(randomIsArchitecture);
         randomSrcLabelConfig.setName(randomIsName);
@@ -40,6 +42,7 @@ public class LabelConfigTest {
         randomSrcLabelConfig.setArchitectureName(randomIsArchitectureName);
         randomSrcLabelConfig.setNameVersion(randomIsNameVersion);
         randomSrcLabelConfig.setArchitectureNameVersion(randomIsArchitectureNameVersion);
+        randomSrcLabelConfig.setWindowsFeatureUpdate(randomIsWindowsFeatureUpdate);
 
         defaultConfig = new LabelConfig();
         randomConfig = new LabelConfig(randomSrcLabelConfig);
@@ -128,5 +131,17 @@ public class LabelConfigTest {
     public void testSetArchitectureNameVersion() {
         defaultConfig.setArchitectureNameVersion(!randomIsArchitectureNameVersion);
         assertThat(defaultConfig.isArchitectureNameVersion(), is(!randomIsArchitectureNameVersion));
+    }
+
+    @Test
+    public void testIsWindowsFeatureUpdate() {
+        assertThat(defaultConfig.isWindowsFeatureUpdate(), is(true));
+        assertThat(randomConfig.isWindowsFeatureUpdate(), is(randomIsWindowsFeatureUpdate));
+    }
+
+    @Test
+    public void testSetWindowsFeatureUpdate() {
+        defaultConfig.setWindowsFeatureUpdate(!randomIsWindowsFeatureUpdate);
+        assertThat(defaultConfig.isWindowsFeatureUpdate(), is(!randomIsWindowsFeatureUpdate));
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseFakeFileTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseFakeFileTest.java
@@ -1,0 +1,43 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class LsbReleaseFakeFileTest {
+    @TempDir
+    File dataDir;
+
+    private String fakeDistributorId = "megasupercorp";
+    private String fakeRelease = "1.2.3";
+    private LsbRelease fakeLsbRelease;
+
+    @BeforeEach
+    void initialize() throws Exception {
+        List<String> data = Arrays.asList("Unexpected line that should be ignored",
+                                          "Distributor ID: " + fakeDistributorId,
+                                          "Release: " + fakeRelease);
+        File dataFile = new File(dataDir, "lsb_release_fake");
+        Files.write(dataFile.toPath(), data, StandardCharsets.UTF_8);
+        fakeLsbRelease = new LsbRelease(dataFile);
+    }
+
+    @Test
+    void matchingFakeDistributorId() {
+        assertThat(fakeLsbRelease.distributorId(), is(fakeDistributorId));
+    }
+
+    @Test
+    void matchingFakeRelease() {
+        assertThat(fakeLsbRelease.release(), is(fakeRelease));
+    }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseFakeTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseFakeTest.java
@@ -1,0 +1,22 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.Test;
+
+public class LsbReleaseFakeTest {
+    private String fakeDistributorId = "megasupercorp";
+    private String fakeRelease = "1.2.3";
+    private LsbRelease fakeLsbRelease = new LsbRelease(fakeDistributorId, fakeRelease);
+
+    @Test
+    void matchingFakeDistributorId() {
+        assertThat(fakeLsbRelease.distributorId(), is(fakeDistributorId));
+    }
+
+    @Test
+    void matchingFakeRelease() {
+        assertThat(fakeLsbRelease.release(), is(fakeRelease));
+    }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseRealTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseRealTest.java
@@ -1,0 +1,26 @@
+package org.jvnet.hudson.plugins.platformlabeler;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LsbReleaseRealTest {
+    private LsbRelease lsbRelease;
+
+    @BeforeEach
+    void initialize() {
+        lsbRelease = new LsbRelease();
+    }
+
+    @Test
+    void nonEmptyRealDistributorId() {
+        assertThat(lsbRelease.distributorId(), is(not(emptyString())));
+    }
+
+    @Test
+    void nonEmptyRealRelease() {
+        assertThat(lsbRelease.release(), is(not(emptyString())));
+    }
+}


### PR DESCRIPTION
## Improve tests based on PIT evaluation

The PIT mutation testing framework detects several cases where a breaking change to the production code would not be detected by the existing automated tests.  These new tests are fast to execute and catch a few of those cases.  More cases remain to be detected and PIT testing still needs to be adapted to run with Java 11.

- Test LsbRelease data fields
- Include windows feature update in LabelConfig test

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
