### PR TITLE
Remove ubi9/9.0.0 test generator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -146,20 +146,6 @@ updates:
       versions: [">= 8.7"]
 
 - package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.0"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - MarkEWaite
-  labels:
-  - skip-changelog
-  ignore:
-    - dependency-name: "Dockerfile"
-      versions: [">= 8.8"]
-
-- package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.1"
   schedule:
     interval: weekly

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.0/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.0/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.0.0-1703


### PR DESCRIPTION
## Remove ubi9/9.0.0 test generator

Superseded by ubi9/9.1.0

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
