### PR TITLE
[JENKINS-70737] Report Debian unstable correctly during freeze

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -62,8 +62,13 @@ public class LsbRelease implements PlatformDetailsRelease {
                 newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
         String guessedRelease =
                 newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-        if (guessedRelease.equals("n/a")) {
-            guessedRelease = guessDebianRelease(guessedRelease);
+        if (this.distributorId.equals("Debian")) {
+            /* Check apt-cache policy in case the Debian distribution is testing or unstable. */
+            String aptCacheRelease = readAptCachePolicy(guessedRelease);
+            if (guessedRelease.equals("n/a")
+                    || !aptCacheRelease.equals(PlatformDetailsTask.UNKNOWN_VALUE_STRING)) {
+                guessedRelease = aptCacheRelease;
+            }
         }
         this.release = guessedRelease;
     }
@@ -84,8 +89,13 @@ public class LsbRelease implements PlatformDetailsRelease {
                 newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
         String guessedRelease =
                 newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-        if (guessedRelease.equals("n/a")) {
-            guessedRelease = guessDebianReleaseFromFile(lsbReleaseFile);
+        if (this.distributorId.equals("Debian")) {
+            /* Check apt-cache policy in case the Debian distribution is testing or unstable. */
+            String aptCacheRelease = readAptCachePolicy(lsbReleaseFile);
+            if (guessedRelease.equals("n/a")
+                    || !aptCacheRelease.equals(PlatformDetailsTask.UNKNOWN_VALUE_STRING)) {
+                guessedRelease = aptCacheRelease;
+            }
         }
         this.release = guessedRelease;
     }
@@ -107,12 +117,23 @@ public class LsbRelease implements PlatformDetailsRelease {
      * data, then the path of that file resolves the question whether
      * the ambiguous Debian version is testing or unstable.
      */
-    private String guessDebianReleaseFromFile(@NonNull File testData) {
+    private String readAptCachePolicy(@NonNull File testData) {
         String unstableDir = File.separator + "unstable" + File.separator;
-        return testData.getPath().contains(unstableDir) ? "unstable" : "testing";
+        String testingDir = File.separator + "testing" + File.separator;
+        if (testData.getPath().contains(unstableDir)) {
+            return "unstable";
+        }
+        if (testData.getPath().contains(testingDir)) {
+            return "testing";
+        }
+        return PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     }
 
     /*
+     * Return Debian codename "unstable" or "testing" if apt-cache
+     * policy indicates the distribution is one of those two
+     * codenames, otherwise return UNKNOWN_VALUE_STRING.
+     *
      * Debian testing has periods during its lifecycle when the
      * lsb_release command cannot distinguish between testing and
      * unstable.  That is an accepted condition for the Debian
@@ -130,7 +151,7 @@ public class LsbRelease implements PlatformDetailsRelease {
      * is used elsewhere to determine version information in case the
      * lsb_release command is not available.
      */
-    private String guessDebianRelease(@NonNull String defaultValue) {
+    private String readAptCachePolicy(@NonNull String defaultValue) {
         String value = defaultValue;
         try {
             Process process = new ProcessBuilder("apt-cache", "policy", "base-files").start();
@@ -143,28 +164,47 @@ public class LsbRelease implements PlatformDetailsRelease {
         return value;
     }
 
-    /* Identifying strings in apt-cache policy output that identify
-     * the unstable distribution
+    /* Identifying strings in apt-cache policy output for the unstable
+     * or testing distributions.
      */
-    private List<String> unstableIdentifiers = Arrays.asList("sid", "unstable");
+    private static final String APT_CACHE_POLICY_SID = " sid/";
+    private static final String APT_CACHE_POLICY_TESTING = " testing/";
+    private static final String APT_CACHE_POLICY_UNSTABLE = " unstable/";
+    private List<String> aptCacheIdentifiers =
+            Arrays.asList(
+                    APT_CACHE_POLICY_SID, APT_CACHE_POLICY_TESTING, APT_CACHE_POLICY_UNSTABLE);
 
     /*
-     * If apt-cache output contains one of the unstableIdentifiers,
-     * report it as unstable.  Otherwise report it as testing.
+     * If apt-cache output contains an aptCacheIdentifier codename,
+     * return the matching distribution.  Otherwise return
+     * UNKNOWN_VALUE_STRING.
      */
     private String readReleaseFromAptCachePolicyOutput(InputStream inputStream) throws IOException {
-        String distribution = "testing";
+        List<String> results;
         try (BufferedReader reader =
                 new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            List<String> results =
+            results =
                     reader.lines()
-                            .filter(line -> unstableIdentifiers.stream().anyMatch(line::contains))
+                            .filter(line -> aptCacheIdentifiers.stream().anyMatch(line::contains))
                             .collect(Collectors.toList());
-            if (!results.isEmpty()) {
-                distribution = "unstable";
-            }
         }
-        return distribution;
+        if (results.isEmpty()) {
+            LOGGER.log(Level.FINEST, "empty apt-cache policy, not testing, sid, or unstable");
+            return PlatformDetailsTask.UNKNOWN_VALUE_STRING;
+        } else if (results.get(0).contains(APT_CACHE_POLICY_TESTING)) {
+            LOGGER.log(Level.FINEST, "apt-cache policy is testing");
+            return "testing";
+        } else if (results.get(0).contains(APT_CACHE_POLICY_UNSTABLE)) {
+            LOGGER.log(Level.FINEST, "apt-cache policy is unstable");
+            return "unstable";
+        } else if (results.get(0).contains(APT_CACHE_POLICY_SID)) {
+            LOGGER.log(Level.FINEST, "apt-cache policy is sid");
+            return "unstable";
+        }
+        LOGGER.log(
+                Level.FINEST,
+                "unexpected non-empty apt-cache policy, not testing, sid, or unstable");
+        return PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     }
 
     /**

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -215,7 +215,7 @@ public class NodeLabelCacheTest {
         }
 
         @Override
-        public RetentionStrategy getRetentionStrategy() {
+        public RetentionStrategy<?> getRetentionStrategy() {
             throw new UnsupportedOperationException("Unsupported");
         }
     }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -285,10 +285,15 @@ public class PlatformDetailsTaskTest {
          * is at least at the beginning of one of the detail values. Allow
          * Debian 10 and CentOS 7 to report their base version
          * in the /etc/os-release file without reporting their incremental
-         * version
+         * version.
+         *
+         * If Debian unstable is in a freeze, then /etc/os-release
+         * will report its version as the upcoming release number.
+         * Debian unstable during the bookworm freeze period reported
+         * `12`.
          */
         String foundValue = version;
-        if (details.getVersion().startsWith(version)) {
+        if (details.getVersion().startsWith(version) || details.getName().equals("Debian")) {
             foundValue = details.getVersion();
         }
         /* If VERSION_ID has the unknown value then handle it as a


### PR DESCRIPTION
## [JENKINS-70737](https://issues.jenkins.io/browse/JENKINS-70737) Report Debian unstable correctly during freeze

During soft freeze and hard freeze before a new Debian release, the /etc/os-release file on Debian unstable looks like the next major release.  That is intentional.  See the [Debian bug tracker](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845651) for details.

When in that state, the apt-cache command can be used to determine the Debian release that is running.

The base-files package is used to query the apt-cache policy because it is required for all Debian installations and because it is the package that provides the `/etc/os-release` file that is used elsewhere to determine version information in case the lsb_release command is not available.

This changes to call `apt-cache policy base-files` on all Debian machines.  If the return value is not `unstable` or `testing` or `sid` then it is ignored.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
