### PR TITLE
Update Debian unstable and testing data

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -157,7 +157,7 @@ public class PlatformDetailsTaskReleaseTest {
         if (parentDir.getName().equals("testing") || parentDir.getName().equals("unstable")) {
             /* Debian unstable and Debian testing are indistinguishable by package definition */
             /* See https://unix.stackexchange.com/questions/464812/ for more details */
-            return "bullseye";
+            return "12";
         }
         return parentDir.getName();
     }

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/lsb_release-a
@@ -1,5 +1,5 @@
 No LSB modules are available.
 Distributor ID:	Debian
-Description:	Debian GNU/Linux bookworm/sid
-Release:	n/a
+Description:	Debian GNU/Linux 12 (bookworm)
+Release:	12
 Codename:	bookworm

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing/os-release
@@ -1,5 +1,7 @@
-PRETTY_NAME="Debian GNU/Linux bookworm/sid"
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
 NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
 VERSION_CODENAME=bookworm
 ID=debian
 HOME_URL="https://www.debian.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/lsb_release-a
@@ -1,5 +1,5 @@
 No LSB modules are available.
 Distributor ID:	Debian
-Description:	Debian GNU/Linux bookworm/sid
-Release:	n/a
+Description:	Debian GNU/Linux 12 (bookworm)
+Release:	12
 Codename:	bookworm

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/unstable/os-release
@@ -1,5 +1,7 @@
-PRETTY_NAME="Debian GNU/Linux bookworm/sid"
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
 NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
 VERSION_CODENAME=bookworm
 ID=debian
 HOME_URL="https://www.debian.org/"


### PR DESCRIPTION
## Update Debian testing & unstable test data

Update sample data for Debian GNU/Linux 12 (bookworm) in the testing distribution and in the unstable distribution.

Condition is temporary until the release of Debian 12 (bookworm).  Once Debian 12 is released, then the release will return to "n/a" and the test code will need to be adapted to the change.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Test
