### PR TITLE
Format code with Palantir Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -42,8 +42,11 @@ import java.util.stream.Collectors;
 
 /** Linux standard base release class. Provides distributor ID and release. */
 public class LsbRelease implements PlatformDetailsRelease {
-    @NonNull private final String distributorId;
-    @NonNull private final String release;
+    @NonNull
+    private final String distributorId;
+
+    @NonNull
+    private final String release;
 
     private static final Logger LOGGER = Logger.getLogger(LsbRelease.class.getName());
 
@@ -58,15 +61,12 @@ public class LsbRelease implements PlatformDetailsRelease {
         } catch (IOException e) {
             LOGGER.log(Level.FINEST, "lsb_release execution failed", e);
         }
-        this.distributorId =
-                newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-        String guessedRelease =
-                newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        this.distributorId = newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        String guessedRelease = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
         if (this.distributorId.equals("Debian")) {
             /* Check apt-cache policy in case the Debian distribution is testing or unstable. */
             String aptCacheRelease = readAptCachePolicy(guessedRelease);
-            if (guessedRelease.equals("n/a")
-                    || !aptCacheRelease.equals(PlatformDetailsTask.UNKNOWN_VALUE_STRING)) {
+            if (guessedRelease.equals("n/a") || !aptCacheRelease.equals(PlatformDetailsTask.UNKNOWN_VALUE_STRING)) {
                 guessedRelease = aptCacheRelease;
             }
         }
@@ -85,25 +85,20 @@ public class LsbRelease implements PlatformDetailsRelease {
         try (FileInputStream stream = new FileInputStream(lsbReleaseFile)) {
             readLsbReleaseOutput(stream, newProps);
         }
-        this.distributorId =
-                newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
-        String guessedRelease =
-                newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        this.distributorId = newProps.getOrDefault("Distributor ID", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
+        String guessedRelease = newProps.getOrDefault("Release", PlatformDetailsTask.UNKNOWN_VALUE_STRING);
         if (this.distributorId.equals("Debian")) {
             /* Check apt-cache policy in case the Debian distribution is testing or unstable. */
             String aptCacheRelease = readAptCachePolicy(lsbReleaseFile);
-            if (guessedRelease.equals("n/a")
-                    || !aptCacheRelease.equals(PlatformDetailsTask.UNKNOWN_VALUE_STRING)) {
+            if (guessedRelease.equals("n/a") || !aptCacheRelease.equals(PlatformDetailsTask.UNKNOWN_VALUE_STRING)) {
                 guessedRelease = aptCacheRelease;
             }
         }
         this.release = guessedRelease;
     }
 
-    private void readLsbReleaseOutput(InputStream inputStream, Map<String, String> newProps)
-            throws IOException {
-        try (BufferedReader reader =
-                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+    private void readLsbReleaseOutput(InputStream inputStream, Map<String, String> newProps) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             reader.lines()
                     .filter(s -> s.contains(":"))
                     .map(line -> line.split(":", 2))
@@ -171,8 +166,7 @@ public class LsbRelease implements PlatformDetailsRelease {
     private static final String APT_CACHE_POLICY_TESTING = " testing/";
     private static final String APT_CACHE_POLICY_UNSTABLE = " unstable/";
     private List<String> aptCacheIdentifiers =
-            Arrays.asList(
-                    APT_CACHE_POLICY_SID, APT_CACHE_POLICY_TESTING, APT_CACHE_POLICY_UNSTABLE);
+            Arrays.asList(APT_CACHE_POLICY_SID, APT_CACHE_POLICY_TESTING, APT_CACHE_POLICY_UNSTABLE);
 
     /*
      * If apt-cache output contains an aptCacheIdentifier codename,
@@ -181,12 +175,10 @@ public class LsbRelease implements PlatformDetailsRelease {
      */
     private String readReleaseFromAptCachePolicyOutput(InputStream inputStream) throws IOException {
         List<String> results;
-        try (BufferedReader reader =
-                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            results =
-                    reader.lines()
-                            .filter(line -> aptCacheIdentifiers.stream().anyMatch(line::contains))
-                            .collect(Collectors.toList());
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            results = reader.lines()
+                    .filter(line -> aptCacheIdentifiers.stream().anyMatch(line::contains))
+                    .collect(Collectors.toList());
         }
         if (results.isEmpty()) {
             LOGGER.log(Level.FINEST, "empty apt-cache policy, not testing, sid, or unstable");
@@ -201,9 +193,7 @@ public class LsbRelease implements PlatformDetailsRelease {
             LOGGER.log(Level.FINEST, "apt-cache policy is sid");
             return "unstable";
         }
-        LOGGER.log(
-                Level.FINEST,
-                "unexpected non-empty apt-cache policy, not testing, sid, or unstable");
+        LOGGER.log(Level.FINEST, "unexpected non-empty apt-cache policy, not testing, sid, or unstable");
         return PlatformDetailsTask.UNKNOWN_VALUE_STRING;
     }
 

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -54,8 +54,7 @@ public class NodeLabelCache extends ComputerListener {
     /** The labels computed for nodes - accessible package wide. */
     static transient Map<Node, Collection<LabelAtom>> nodeLabels = new WeakHashMap<>();
     /** Logging of issues. */
-    private static final transient Logger LOGGER =
-            Logger.getLogger("org.jvnet.hudson.plugins.platformlabeler");
+    private static final transient Logger LOGGER = Logger.getLogger("org.jvnet.hudson.plugins.platformlabeler");
 
     /**
      * When a computer comes online, probe it for its platform labels.
@@ -76,10 +75,9 @@ public class NodeLabelCache extends ComputerListener {
     @Override
     public final void onConfigurationChange() {
         synchronized (nodePlatformProperties) {
-            nodePlatformProperties.forEach(
-                    (node, labels) -> {
-                        refreshModel(node);
-                    });
+            nodePlatformProperties.forEach((node, labels) -> {
+                refreshModel(node);
+            });
         }
     }
 
@@ -119,8 +117,7 @@ public class NodeLabelCache extends ComputerListener {
      * @throws InterruptedException on thread interruption
      */
     @NonNull
-    PlatformDetails requestComputerPlatformDetails(final Computer computer)
-            throws IOException, InterruptedException {
+    PlatformDetails requestComputerPlatformDetails(final Computer computer) throws IOException, InterruptedException {
         final VirtualChannel channel = computer.getChannel();
         if (null == channel) {
             // Cannot obtain details from an unconnected node. While we should
@@ -201,13 +198,11 @@ public class NodeLabelCache extends ComputerListener {
      * @return The labelConfig to be used for the node
      */
     private LabelConfig getLabelConfig(final Node node) {
-        LabelConfig labelConfig =
-                GlobalConfiguration.all()
-                        .getInstance(PlatformLabelerGlobalConfiguration.class)
-                        .getLabelConfig();
+        LabelConfig labelConfig = GlobalConfiguration.all()
+                .getInstance(PlatformLabelerGlobalConfiguration.class)
+                .getLabelConfig();
 
-        PlatformLabelerNodeProperty nodeProperty =
-                node.getNodeProperty(PlatformLabelerNodeProperty.class);
+        PlatformLabelerNodeProperty nodeProperty = node.getNodeProperty(PlatformLabelerNodeProperty.class);
 
         if (nodeProperty != null) {
             labelConfig = nodeProperty.getLabelConfig();

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -36,8 +36,7 @@ public class PlatformDetails implements Serializable {
      * @param windowsFeatureUpdate windows feature update version string, as in 1809, 1903, 2009,
      *     2103, etc.
      */
-    public PlatformDetails(
-            String name, String architecture, String version, String windowsFeatureUpdate) {
+    public PlatformDetails(String name, String architecture, String version, String windowsFeatureUpdate) {
         this.name = name;
         this.architecture = architecture;
         this.version = version;

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -87,9 +87,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         return computeLabels(arch, name, version);
     }
 
-    @SuppressFBWarnings(
-            value = "IMPROPER_UNICODE",
-            justification = "Strings are ASCII, safe to ignore case")
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "Strings are ASCII, safe to ignore case")
     private boolean equalsIgnoreCase(@NonNull String s1, @NonNull String s2) {
         return s1.equalsIgnoreCase(s2);
     }
@@ -142,8 +140,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
     }
 
     /* Package protected for testing */
-    String getCanonicalLinuxArchStream(@NonNull InputStream stream, @NonNull String arch)
-            throws IOException {
+    String getCanonicalLinuxArchStream(@NonNull InputStream stream, @NonNull String arch) throws IOException {
         try (BufferedReader b = new BufferedReader(new InputStreamReader(stream, "UTF-8"))) {
             String line = b.readLine();
             if (line != null) {
@@ -169,8 +166,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
      */
     @NonNull
     protected PlatformDetails computeLabels(
-            @NonNull final String arch, @NonNull final String name, @NonNull final String version)
-            throws IOException {
+            @NonNull final String arch, @NonNull final String name, @NonNull final String version) throws IOException {
         if (name.toLowerCase(Locale.ENGLISH).startsWith("linux")) {
             return computeLabels(arch, name, version, new LsbRelease());
         }
@@ -180,9 +176,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         return computeLabels(arch, name, version, null);
     }
 
-    @SuppressFBWarnings(
-            value = "IMPROPER_UNICODE",
-            justification = "Strings are ASCII, safe to lower case")
+    @SuppressFBWarnings(value = "IMPROPER_UNICODE", justification = "Strings are ASCII, safe to lower case")
     private String toLowerCase(@NonNull String s1) {
         return s1.toLowerCase(Locale.ENGLISH);
     }
@@ -211,11 +205,8 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         String windowsFeatureUpdate = null;
         if (computedName.startsWith("windows")) {
             computedName = "windows";
-            computedArch =
-                    checkWindows32Bit(
-                            computedArch,
-                            System.getenv("PROCESSOR_ARCHITECTURE"),
-                            System.getenv("PROCESSOR_ARCHITEW6432"));
+            computedArch = checkWindows32Bit(
+                    computedArch, System.getenv("PROCESSOR_ARCHITECTURE"), System.getenv("PROCESSOR_ARCHITEW6432"));
             if (computedVersion.startsWith("4.0")) {
                 computedVersion = "nt4";
             } else if (computedVersion.startsWith("5.0")) {
@@ -226,8 +217,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
                 computedVersion = "2003";
             }
             final boolean recentWindows = computedVersion.startsWith("10");
-            if (release != null
-                    && recentWindows) { // Feature updates only in recent Windows versions
+            if (release != null && recentWindows) { // Feature updates only in recent Windows versions
                 windowsFeatureUpdate = release.release();
                 if (windowsFeatureUpdate.isEmpty()) {
                     windowsFeatureUpdate = null;
@@ -256,8 +246,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             if (computedVersion.equals(UNKNOWN_VALUE_STRING)) {
                 computedVersion = getRedhatReleaseIdentifier("VERSION_ID");
             }
-            if (equalsIgnoreCase(computedName, "debian")
-                    && computedVersion.equals(UNKNOWN_VALUE_STRING)) {
+            if (equalsIgnoreCase(computedName, "debian") && computedVersion.equals(UNKNOWN_VALUE_STRING)) {
                 /* Debian unstable and Debian testing don't include version in os-release */
                 /* Try reading it from a different location */
                 computedVersion = getDebianVersionIdentifier();
@@ -267,8 +256,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
              * release "n/a".  Embedding a "/" in the label will cause problems
              * like those described in JENKINS-64324.
              */
-            if (equalsIgnoreCase(computedName, "debian")
-                    && equalsIgnoreCase(computedVersion, "n/a")) {
+            if (equalsIgnoreCase(computedName, "debian") && equalsIgnoreCase(computedVersion, "n/a")) {
                 computedVersion = "unstable";
             }
             /* JENKINS-64324 notes that labels with '/' break various Jenkins components */
@@ -298,8 +286,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             if (computedName.equals("SUSE LINUX")) {
                 computedName = "SUSE";
                 try {
-                    String integerPortion =
-                            computedVersion.replaceAll("([0-9]+)([.][0-9]+)*", "$1");
+                    String integerPortion = computedVersion.replaceAll("([0-9]+)([.][0-9]+)*", "$1");
                     int intVersion = Integer.parseInt(integerPortion);
                     if (intVersion <= 11) {
                         String newVersion = getSuseReleaseIdentifier("VERSION_ID");
@@ -321,8 +308,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             computedName = "mac";
         }
         PlatformDetails properties =
-                new PlatformDetails(
-                        computedName, computedArch, computedVersion, windowsFeatureUpdate);
+                new PlatformDetails(computedName, computedArch, computedVersion, windowsFeatureUpdate);
         return properties;
     }
 
@@ -396,8 +382,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             return value;
         }
         try (BufferedReader br =
-                new BufferedReader(
-                        Files.newBufferedReader(osRelease.toPath(), StandardCharsets.UTF_8))) {
+                new BufferedReader(Files.newBufferedReader(osRelease.toPath(), StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 if (line.startsWith(field + "=")) {
@@ -420,8 +405,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             return value;
         }
         try (BufferedReader br =
-                new BufferedReader(
-                        Files.newBufferedReader(redhatRelease.toPath(), StandardCharsets.UTF_8))) {
+                new BufferedReader(Files.newBufferedReader(redhatRelease.toPath(), StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 if (line.contains(RELEASE)) {
@@ -429,11 +413,8 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
                         value = line.substring(0, line.indexOf(RELEASE)).trim();
                     }
                     if (field.equals("VERSION_ID")) {
-                        value =
-                                line.substring(
-                                                line.indexOf(RELEASE) + RELEASE.length(),
-                                                line.indexOf("("))
-                                        .trim();
+                        value = line.substring(line.indexOf(RELEASE) + RELEASE.length(), line.indexOf("("))
+                                .trim();
                     }
                 }
             }
@@ -455,8 +436,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             return value;
         }
         try (BufferedReader br =
-                new BufferedReader(
-                        Files.newBufferedReader(suseRelease.toPath(), StandardCharsets.UTF_8))) {
+                new BufferedReader(Files.newBufferedReader(suseRelease.toPath(), StandardCharsets.UTF_8))) {
             String line;
             while ((line = br.readLine()) != null) {
                 if (line.startsWith(VERSION)) {
@@ -493,9 +473,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
     String getDebianVersionIdentifier() {
         if (debianVersion != null) {
             try (BufferedReader br =
-                    new BufferedReader(
-                            Files.newBufferedReader(
-                                    debianVersion.toPath(), StandardCharsets.UTF_8))) {
+                    new BufferedReader(Files.newBufferedReader(debianVersion.toPath(), StandardCharsets.UTF_8))) {
                 String line = br.readLine();
                 return line != null ? line.trim() : UNKNOWN_VALUE_STRING;
             } catch (IOException notFound) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
@@ -37,31 +37,29 @@ import java.util.Map;
 
 /** Windows release class. Provides Windows feature update, 1803, 1903, 2009, 2103, 2109, etc. */
 public class WindowsRelease implements PlatformDetailsRelease {
-    @NonNull private final String release;
+    @NonNull
+    private final String release;
 
     /** Extract distributor ID and release for current platform. */
     public WindowsRelease() {
         Map<String, String> newProps = new HashMap<>();
         try {
-            Process process =
-                    new ProcessBuilder(
-                                    "REG",
-                                    "QUERY",
-                                    "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion",
-                                    "/t",
-                                    "REG_SZ",
-                                    "/v",
-                                    "ReleaseId")
-                            .start();
+            Process process = new ProcessBuilder(
+                            "REG",
+                            "QUERY",
+                            "HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion",
+                            "/t",
+                            "REG_SZ",
+                            "/v",
+                            "ReleaseId")
+                    .start();
             try (InputStream stream = process.getInputStream()) {
                 readWindowsReleaseOutput(stream, newProps);
             }
         } catch (IOException ignored) {
             // IGNORE
         }
-        this.release =
-                newProps.getOrDefault(
-                        "ReleaseId", PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING);
+        this.release = newProps.getOrDefault("ReleaseId", PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING);
     }
 
     /** Read file to assign distributor ID and release. Package protected for tests. */
@@ -70,15 +68,11 @@ public class WindowsRelease implements PlatformDetailsRelease {
         try (FileInputStream stream = new FileInputStream(windowsReleaseFile)) {
             readWindowsReleaseOutput(stream, newProps);
         }
-        this.release =
-                newProps.getOrDefault(
-                        "ReleaseId", PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING);
+        this.release = newProps.getOrDefault("ReleaseId", PlatformDetailsTask.UNKNOWN_WINDOWS_VALUE_STRING);
     }
 
-    private void readWindowsReleaseOutput(InputStream inputStream, Map<String, String> newProps)
-            throws IOException {
-        try (BufferedReader reader =
-                new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+    private void readWindowsReleaseOutput(InputStream inputStream, Map<String, String> newProps) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             reader.lines()
                     .filter(s -> s.contains("REG_SZ"))
                     .map(line -> line.split("REG_SZ", 2))

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -17,7 +17,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ConfigurationTest {
-    @Rule public final JenkinsRule r = new JenkinsRule();
+    @Rule
+    public final JenkinsRule r = new JenkinsRule();
 
     private Computer computer;
     private NodeLabelCache nodeLabelCache;
@@ -173,13 +174,10 @@ public class ConfigurationTest {
         LabelConfig globalLabelConfigBefore = globalConfig.getLabelConfig();
         r.configRoundtrip();
         LabelConfig globalLabelConfigAfter = globalConfig.getLabelConfig();
-        assertThat(
-                globalLabelConfigBefore.isArchitecture(),
-                is(globalLabelConfigAfter.isArchitecture()));
+        assertThat(globalLabelConfigBefore.isArchitecture(), is(globalLabelConfigAfter.isArchitecture()));
         assertThat(globalLabelConfigBefore.isName(), is(globalLabelConfigAfter.isName()));
         assertThat(globalLabelConfigBefore.isVersion(), is(globalLabelConfigAfter.isVersion()));
         assertThat(
-                globalLabelConfigBefore.isWindowsFeatureUpdate(),
-                is(globalLabelConfigAfter.isWindowsFeatureUpdate()));
+                globalLabelConfigBefore.isWindowsFeatureUpdate(), is(globalLabelConfigAfter.isWindowsFeatureUpdate()));
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfigTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfigTest.java
@@ -56,9 +56,7 @@ public class LabelConfigTest {
         assertThat(nullLabelConfig.isVersion(), is(defaultConfig.isVersion()));
         assertThat(nullLabelConfig.isArchitectureName(), is(defaultConfig.isArchitectureName()));
         assertThat(nullLabelConfig.isNameVersion(), is(defaultConfig.isNameVersion()));
-        assertThat(
-                nullLabelConfig.isArchitectureNameVersion(),
-                is(defaultConfig.isArchitectureNameVersion()));
+        assertThat(nullLabelConfig.isArchitectureNameVersion(), is(defaultConfig.isArchitectureNameVersion()));
     }
 
     @Test

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseFakeFileTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LsbReleaseFakeFileTest.java
@@ -13,7 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class LsbReleaseFakeFileTest {
-    @TempDir File dataDir;
+    @TempDir
+    File dataDir;
 
     private String fakeDistributorId = "megasupercorp";
     private String fakeRelease = "1.2.3";
@@ -21,11 +22,10 @@ public class LsbReleaseFakeFileTest {
 
     @BeforeEach
     void initialize() throws Exception {
-        List<String> data =
-                Arrays.asList(
-                        "Unexpected line that should be ignored",
-                        "Distributor ID: " + fakeDistributorId,
-                        "Release: " + fakeRelease);
+        List<String> data = Arrays.asList(
+                "Unexpected line that should be ignored",
+                "Distributor ID: " + fakeDistributorId,
+                "Release: " + fakeRelease);
         File dataFile = new File(dataDir, "lsb_release_fake");
         Files.write(dataFile.toPath(), data, StandardCharsets.UTF_8);
         fakeLsbRelease = new LsbRelease(dataFile);

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -42,7 +42,8 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  */
 public class NodeLabelCacheTest {
 
-    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     public NodeLabelCacheTest() {
         /* Intentionally empty constructor */
@@ -60,11 +61,10 @@ public class NodeLabelCacheTest {
         assertThat(labelsBefore, is(not(empty())));
         nodeLabelCache = new NodeLabelCache();
         PlatformDetailsTask task = new PlatformDetailsTask();
-        localDetails =
-                task.computeLabels(
-                        System.getProperty("os.arch", PlatformDetailsTask.UNKNOWN_VALUE_STRING),
-                        System.getProperty("os.name", PlatformDetailsTask.UNKNOWN_VALUE_STRING),
-                        System.getProperty("os.version", PlatformDetailsTask.UNKNOWN_VALUE_STRING));
+        localDetails = task.computeLabels(
+                System.getProperty("os.arch", PlatformDetailsTask.UNKNOWN_VALUE_STRING),
+                System.getProperty("os.name", PlatformDetailsTask.UNKNOWN_VALUE_STRING),
+                System.getProperty("os.version", PlatformDetailsTask.UNKNOWN_VALUE_STRING));
     }
 
     @After
@@ -116,9 +116,7 @@ public class NodeLabelCacheTest {
         assertThat(platformDetails.getArchitecture(), is(localDetails.getArchitecture()));
         assertThat(platformDetails.getName(), is(localDetails.getName()));
         assertThat(platformDetails.getVersion(), is(localDetails.getVersion()));
-        assertThat(
-                platformDetails.getWindowsFeatureUpdate(),
-                is(localDetails.getWindowsFeatureUpdate()));
+        assertThat(platformDetails.getWindowsFeatureUpdate(), is(localDetails.getWindowsFeatureUpdate()));
     }
 
     @Test
@@ -194,8 +192,7 @@ public class NodeLabelCacheTest {
 
         @Override
         @RequirePOST
-        public void doLaunchSlaveAgent(StaplerRequest sr, StaplerResponse sr1)
-                throws IOException, ServletException {
+        public void doLaunchSlaveAgent(StaplerRequest sr, StaplerResponse sr1) throws IOException, ServletException {
             throw new UnsupportedOperationException("Unsupported");
         }
 
@@ -227,6 +224,7 @@ public class NodeLabelCacheTest {
             this.exceptionToThrow = exceptionToThrow;
         }
 
+        @Override
         public <V, T extends Throwable> V call(Callable<V, T> callable) throws IOException {
             if (exceptionToThrow != null) {
                 throw exceptionToThrow;
@@ -234,82 +232,100 @@ public class NodeLabelCacheTest {
             return null;
         }
 
-        public <V, T extends Throwable> hudson.remoting.Future<V> callAsync(
-                Callable<V, T> callable) {
+        @Override
+        public <V, T extends Throwable> hudson.remoting.Future<V> callAsync(Callable<V, T> callable) {
             return null;
         }
 
+        @Override
         public <T> T export(java.lang.Class<T> type, T instance) {
             return null;
         }
 
+        @Override
         public void join() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public void join(long timeout) {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public void syncLocalIO() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public void close() {
             throw new UnsupportedOperationException("Unsupported");
         }
     }
 
     private class NullingNode extends Node {
+        @Override
         public Callable<ClockDifference, IOException> getClockDifferenceCallable() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public NodeDescriptor getDescriptor() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public DescribableList<NodeProperty<?>, NodePropertyDescriptor> getNodeProperties() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public FilePath getRootPath() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public FilePath getWorkspaceFor(TopLevelItem item) {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public String getLabelString() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public Computer createComputer() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public Node.Mode getMode() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public int getNumExecutors() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public Launcher createLauncher(TaskListener listener) {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public String getNodeDescription() {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         @Deprecated
         public void setNodeName(String name) {
             throw new UnsupportedOperationException("Unsupported");
         }
 
+        @Override
         public String getNodeName() {
             throw new UnsupportedOperationException("Unsupported");
         }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsCheckRolesTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsCheckRolesTest.java
@@ -17,7 +17,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 public class PlatformDetailsCheckRolesTest {
 
-    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     private PlatformDetailsTask platformDetailsTask;
 
@@ -28,32 +29,27 @@ public class PlatformDetailsCheckRolesTest {
 
     @Test
     public void testCheckRoles() {
-        RoleChecker checker =
-                new RoleChecker() {
-                    @Override
-                    public void check(RoleSensitive rs, Collection<Role> roleCollection)
-                            throws SecurityException {
-                        if (!roleCollection.contains(Roles.SLAVE)) {
-                            throw new SecurityException(Roles.SLAVE + " missing");
-                        }
-                    }
-                };
+        RoleChecker checker = new RoleChecker() {
+            @Override
+            public void check(RoleSensitive rs, Collection<Role> roleCollection) throws SecurityException {
+                if (!roleCollection.contains(Roles.SLAVE)) {
+                    throw new SecurityException(Roles.SLAVE + " missing");
+                }
+            }
+        };
         platformDetailsTask.checkRoles(checker);
     }
 
     @Test(expected = SecurityException.class)
     public void testCheckRolesThrowsSecurityException() {
-        RoleChecker exceptionThrowingChecker =
-                new RoleChecker() {
-                    @Override
-                    public void check(RoleSensitive rs, Collection<Role> roleCollection)
-                            throws SecurityException {
-                        if (roleCollection.contains(Roles.SLAVE)) {
-                            throw new SecurityException(
-                                    Roles.SLAVE + " found, throwing intentional exception");
-                        }
-                    }
-                };
+        RoleChecker exceptionThrowingChecker = new RoleChecker() {
+            @Override
+            public void check(RoleSensitive rs, Collection<Role> roleCollection) throws SecurityException {
+                if (roleCollection.contains(Roles.SLAVE)) {
+                    throw new SecurityException(Roles.SLAVE + " found, throwing intentional exception");
+                }
+            }
+        };
         platformDetailsTask.checkRoles(exceptionThrowingChecker);
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -26,7 +26,8 @@ public class PlatformDetailsTaskLsbReleaseTest {
      * @return parameter values to be tested
      */
     public static Stream<Object[]> generateReleaseFileNames() {
-        String packageName = PlatformDetailsTaskLsbReleaseTest.class.getPackage().getName();
+        String packageName =
+                PlatformDetailsTaskLsbReleaseTest.class.getPackage().getName();
         Reflections reflections = new Reflections(packageName, Scanners.Resources);
         Set<String> fileNames = reflections.getResources(Pattern.compile(".*lsb_release-a"));
         Collection<Object[]> data = new ArrayList<>(fileNames.size());
@@ -45,10 +46,7 @@ public class PlatformDetailsTaskLsbReleaseTest {
     @MethodSource("generateReleaseFileNames")
     @DisplayName("Compute os-release labels")
     void testComputeLabelsForOsRelease(
-            String lsbReleaseFileName,
-            String expectedName,
-            String expectedVersion,
-            String expectedArch)
+            String lsbReleaseFileName, String expectedName, String expectedVersion, String expectedArch)
             throws Exception {
         PlatformDetailsTask details = new PlatformDetailsTask();
         URL resource = getClass().getResource(lsbReleaseFileName);
@@ -65,9 +63,7 @@ public class PlatformDetailsTaskLsbReleaseTest {
         assertThat(result.getVersion(), is(expectedVersion));
         assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
         assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
-        assertThat(
-                result.getArchitectureNameVersion(),
-                is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+        assertThat(result.getArchitectureNameVersion(), is(expectedArch + "-" + expectedName + "-" + expectedVersion));
     }
 
     private static String computeExpectedName(String filename) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -46,11 +46,7 @@ public class PlatformDetailsTaskReleaseTest {
     @MethodSource("generateReleaseFileNames")
     @DisplayName("Compute platform details from release file")
     void testComputeLabelsForRelease(
-            String releaseFileName,
-            String expectedName,
-            String expectedVersion,
-            String expectedArch)
-            throws Exception {
+            String releaseFileName, String expectedName, String expectedVersion, String expectedArch) throws Exception {
         PlatformDetailsTask details = new PlatformDetailsTask();
         URL resource = getClass().getResource(releaseFileName);
         File releaseFile = new File(resource.toURI());
@@ -87,9 +83,7 @@ public class PlatformDetailsTaskReleaseTest {
         assertThat(result.getArchitecture(), is(expectedArch));
         assertThat(result.getVersion(), is(expectedVersion));
         assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
-        assertThat(
-                result.getArchitectureNameVersion(),
-                is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+        assertThat(result.getArchitectureNameVersion(), is(expectedArch + "-" + expectedName + "-" + expectedVersion));
         assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
     }
 

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -27,42 +27,40 @@ public class PlatformDetailsTaskStaticStringTest {
      * @return parameter values to be tested
      */
     public static Stream<Object[]> generateTestParameters() {
-        Collection<Object[]> data =
-                Arrays.asList(
-                        new Object[][] {
-                            /** General cases for operating system names in platformlabeler-1.1 */
-                            {"mac", "amd64", "11.0"}, // macOS
-                            {"Solaris", "amd64", "11.3"}, // Solaris
-                            {"Solaris", "sparc", "11.3"}, // Solaris
-                            {"SunOS", "sparc", "4.1.4"}, // SunOS
-                            /**
-                             * Special Windows version cases using version names in
-                             * platformlabeler-1.1
-                             */
-                            {"Windows 2000", "amd64", "5.0"}, // Win2000
-                            {"Windows 2000", "x86", "5.0"}, // Win2000
-                            {"Windows 2003", "amd64", "5.2"}, // Win2003
-                            {"Windows 2003", "x86", "5.2"}, // Win2003
-                            {"Windows NT", "amd64", "4.0"}, // WinNT
-                            {"Windows NT", "x86", "4.0"}, // WinNT
-                            {"Windows XP", "amd64", "5.1"}, // WinXP
-                            {"Windows XP", "x86", "5.1"}, // WinXP
-                            /**
-                             * General Windows version cases using version numbers in
-                             * platformlabeler-1.1
-                             */
-                            {"Windows 10", "amd64", "10.0"}, // Win10
-                            {"Windows 10", "x86", "10.0"}, // Win10
-                            {"Windows 2008R2", "amd64", "6.1"}, // Win2008R2
-                            {"Windows 7", "amd64", "6.1"}, // Win7
-                            {"Windows 7", "x86", "6.1"}, // Win7
-                            {"Windows Server 2012 R2", "amd64", "6.3"}, // Win2012R2
-                            {"Windows Vista64", "amd64", "6.0.6001"}, // WinVista
-                            {"Windows Vista", "amd64", "6.0.6000"}, // WinVista
-                            {"Windows Vista", "x86", "6.0.6000"}, // WinVista
-                            /** General case for operating systems unknown to platformlabeler-1.1 */
-                            {"FreeBSD", "amd64", "10.3-STABLE"}, // FreeBSD
-                        });
+        Collection<Object[]> data = Arrays.asList(new Object[][] {
+            /** General cases for operating system names in platformlabeler-1.1 */
+            {"mac", "amd64", "11.0"}, // macOS
+            {"Solaris", "amd64", "11.3"}, // Solaris
+            {"Solaris", "sparc", "11.3"}, // Solaris
+            {"SunOS", "sparc", "4.1.4"}, // SunOS
+            /**
+             * Special Windows version cases using version names in
+             * platformlabeler-1.1
+             */
+            {"Windows 2000", "amd64", "5.0"}, // Win2000
+            {"Windows 2000", "x86", "5.0"}, // Win2000
+            {"Windows 2003", "amd64", "5.2"}, // Win2003
+            {"Windows 2003", "x86", "5.2"}, // Win2003
+            {"Windows NT", "amd64", "4.0"}, // WinNT
+            {"Windows NT", "x86", "4.0"}, // WinNT
+            {"Windows XP", "amd64", "5.1"}, // WinXP
+            {"Windows XP", "x86", "5.1"}, // WinXP
+            /**
+             * General Windows version cases using version numbers in
+             * platformlabeler-1.1
+             */
+            {"Windows 10", "amd64", "10.0"}, // Win10
+            {"Windows 10", "x86", "10.0"}, // Win10
+            {"Windows 2008R2", "amd64", "6.1"}, // Win2008R2
+            {"Windows 7", "amd64", "6.1"}, // Win7
+            {"Windows 7", "x86", "6.1"}, // Win7
+            {"Windows Server 2012 R2", "amd64", "6.3"}, // Win2012R2
+            {"Windows Vista64", "amd64", "6.0.6001"}, // WinVista
+            {"Windows Vista", "amd64", "6.0.6000"}, // WinVista
+            {"Windows Vista", "x86", "6.0.6000"}, // WinVista
+            /** General case for operating systems unknown to platformlabeler-1.1 */
+            {"FreeBSD", "amd64", "10.3-STABLE"}, // FreeBSD
+        });
 
         /* Don't add data for this platform if linux - linux decodes the distribution as a label */
         String myName = System.getProperty("os.name");
@@ -74,9 +72,7 @@ public class PlatformDetailsTaskStaticStringTest {
         String myArch = System.getProperty("os.arch");
         String myVersion = System.getProperty("os.version");
         for (Object[] testData : data) {
-            if (testData[0].equals(myName)
-                    && testData[1].equals(myArch)
-                    && testData[2].equals(myVersion)) {
+            if (testData[0].equals(myName) && testData[1].equals(myArch) && testData[2].equals(myVersion)) {
                 return data.stream();
             }
         }
@@ -160,8 +156,7 @@ public class PlatformDetailsTaskStaticStringTest {
         try {
             Process p = Runtime.getRuntime().exec("/bin/freebsd-version -u");
             p.waitFor();
-            try (BufferedReader b =
-                    new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
+            try (BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream(), "UTF-8"))) {
                 String line = b.readLine();
                 if (line != null) {
                     version = line;

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -30,8 +30,7 @@ public class PlatformDetailsTaskTest {
      * SPECIAL_CASE_ARCH is used to test x86 detection when running on 64 bit Intel processors. When
      * running on non-Intel processors, use the system architecture reported by Java.
      */
-    private static final String SPECIAL_CASE_ARCH =
-            SYSTEM_OS_ARCH.contains("amd") ? "x86" : SYSTEM_OS_ARCH;
+    private static final String SPECIAL_CASE_ARCH = SYSTEM_OS_ARCH.contains("amd") ? "x86" : SYSTEM_OS_ARCH;
 
     @BeforeEach
     void createPlatformDetailsTask() {
@@ -79,10 +78,7 @@ public class PlatformDetailsTaskTest {
             // Yes, this is a dirty trick to detect the hardware architecture on some JVM's
             String expectedArch = SYSTEM_OS_ARCH;
             if (expectedArch.equals("amd64")) {
-                expectedArch =
-                        System.getProperty("sun.arch.data.model", "23").equals("32")
-                                ? "x86"
-                                : "amd64";
+                expectedArch = System.getProperty("sun.arch.data.model", "23").equals("32") ? "x86" : "amd64";
             }
             // Assumes tests run in JVM that matches operating system
             assertThat(details.getArchitecture(), is(expectedArch));
@@ -92,8 +88,7 @@ public class PlatformDetailsTaskTest {
     @Test
     @DisplayName("test 32 bit Linux label computation")
     void testComputeLabelsCanonicalLinuxArch() throws Exception {
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        PlatformDetails details = platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
         assertPlatformDetails(details);
     }
 
@@ -102,9 +97,7 @@ public class PlatformDetailsTaskTest {
     void testCanonicalLinuxArchStream() throws IOException {
         String unameOutput = "x86_64";
         InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
-        assertThat(
-                platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH),
-                is("amd64"));
+        assertThat(platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH), is("amd64"));
     }
 
     @Test
@@ -112,9 +105,7 @@ public class PlatformDetailsTaskTest {
     void testCanonicalLinuxArchStreamARM() throws IOException {
         String unameOutput = "aarch64";
         InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
-        assertThat(
-                platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH),
-                is(unameOutput));
+        assertThat(platformDetailsTask.getCanonicalLinuxArchStream(stream, SPECIAL_CASE_ARCH), is(unameOutput));
     }
 
     @Test
@@ -123,9 +114,7 @@ public class PlatformDetailsTaskTest {
         String unameOutput = "";
         String expectedArch = "Expected-Arch";
         InputStream stream = new ByteArrayInputStream(unameOutput.getBytes(StandardCharsets.UTF_8));
-        assertThat(
-                platformDetailsTask.getCanonicalLinuxArchStream(stream, expectedArch),
-                is(expectedArch));
+        assertThat(platformDetailsTask.getCanonicalLinuxArchStream(stream, expectedArch), is(expectedArch));
     }
 
     @Test
@@ -136,8 +125,7 @@ public class PlatformDetailsTaskTest {
         }
         String unknown = PlatformDetailsTask.UNKNOWN_VALUE_STRING;
         LsbRelease release = new LsbRelease(unknown, unknown);
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
+        PlatformDetails details = platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
         assertPlatformDetails(details);
     }
 
@@ -148,8 +136,7 @@ public class PlatformDetailsTaskTest {
             return;
         }
         LsbRelease release = null;
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
+        PlatformDetails details = platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy", release);
         assertPlatformDetails(details);
     }
 
@@ -187,8 +174,9 @@ public class PlatformDetailsTaskTest {
         if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
             return;
         }
-        String computedName =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy").getName();
+        String computedName = platformDetailsTask
+                .computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy")
+                .getName();
         String readName = platformDetailsTask.getReleaseIdentifier("ID");
         assertThat(computedName, is(readName));
     }
@@ -278,8 +266,7 @@ public class PlatformDetailsTaskTest {
         if (isWindows() || !Files.exists(Paths.get("/etc/os-release"))) {
             return;
         }
-        PlatformDetails details =
-                platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
+        PlatformDetails details = platformDetailsTask.computeLabels(SPECIAL_CASE_ARCH, "linux", "xyzzy");
         String version = platformDetailsTask.getReleaseIdentifier("VERSION_ID");
         /* Check that the version string returned by getReleaseIdentifier
          * is at least at the beginning of one of the detail values. Allow

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskWindowsReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskWindowsReleaseTest.java
@@ -25,7 +25,8 @@ public class PlatformDetailsTaskWindowsReleaseTest {
      * @return parameter values to be tested
      */
     public static Stream<Object[]> generateWindowsReleaseFileNames() {
-        String packageName = PlatformDetailsTaskWindowsReleaseTest.class.getPackage().getName();
+        String packageName =
+                PlatformDetailsTaskWindowsReleaseTest.class.getPackage().getName();
         Reflections reflections = new Reflections(packageName, Scanners.Resources);
         Set<String> fileNames = reflections.getResources(Pattern.compile(".*reg-query"));
         Collection<Object[]> data = new ArrayList<>(fileNames.size());
@@ -44,10 +45,7 @@ public class PlatformDetailsTaskWindowsReleaseTest {
     @MethodSource("generateWindowsReleaseFileNames")
     @DisplayName("Compute reg-query labels")
     void testComputeLabelsForOsRelease(
-            String windowsReleaseFileName,
-            String expectedName,
-            String expectedVersion,
-            String expectedArch)
+            String windowsReleaseFileName, String expectedName, String expectedVersion, String expectedArch)
             throws Exception {
         PlatformDetailsTask details = new PlatformDetailsTask();
         URL resource = getClass().getResource(windowsReleaseFileName);
@@ -57,9 +55,7 @@ public class PlatformDetailsTaskWindowsReleaseTest {
         PlatformDetails result = details.computeLabels("amd64", "windows", "10.0", release);
         assertThat(result.getArchitecture(), is(expectedArch));
         assertThat(result.getArchitectureName(), is(expectedArch + "-" + expectedName));
-        assertThat(
-                result.getArchitectureNameVersion(),
-                is(expectedArch + "-" + expectedName + "-" + expectedVersion));
+        assertThat(result.getArchitectureNameVersion(), is(expectedArch + "-" + expectedName + "-" + expectedVersion));
         assertThat(result.getName(), is(expectedName));
         assertThat(result.getNameVersion(), is(expectedName + "-" + expectedVersion));
         assertThat(result.getVersion(), is(expectedVersion));

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -126,15 +126,7 @@ public class PlatformDetailsTest {
 
     private final Random random = new Random();
     private final String[] names = {
-        "Windows 10",
-        "alpine",
-        "centos",
-        "debian",
-        "fedora",
-        "freebsd",
-        "macos",
-        "raspbian",
-        "ubuntu"
+        "Windows 10", "alpine", "centos", "debian", "fedora", "freebsd", "macos", "raspbian", "ubuntu"
     };
     private final String[] versions = {
         "3.14.9",

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerTest.java
@@ -38,7 +38,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 public class PlatformLabelerTest {
 
-    @Rule public final JenkinsRule j = new JenkinsRule();
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
 
     @Test
     public void testLookupCached() {


### PR DESCRIPTION
Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its [Rectangle Rule](https://github.com/google/google-java-format/wiki/The-Rectangle-Rule) has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted `plugin-compat-tester` this way in https://github.com/jenkinsci/plugin-compat-tester/pull/506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity.