### PR TITLE
Extend gitattributes to avoid Windows formatting errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,9 @@
+Dockerfile text eol=lf
+*.html text eol=lf
 *.java text eol=lf
+*.jelly text eol=lf
+*.md text eol=lf
+*.sh text eol=lf
+*.txt text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf


### PR DESCRIPTION
# Extend gitattributes to avoid Windows formatting errors

Text files in the repository should use LF as end of line

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Maintenance
