### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import java.util.Collections
 
 // Valid Jenkins versions for markwaite.net test
-def testJenkinsVersions = [ '2.375.4', '2.387.1', '2.387.2', '2.395', '2.396', '2.397', '2.398', '2.399', '2.400' ]
+def testJenkinsVersions = [ '2.387.3', '2.401', '2.402', '2.403', '2.404', '2.405', '2.406', '2.407' ]
 Collections.shuffle(testJenkinsVersions)
 
 // build with randomized Jenkins versions
@@ -40,7 +40,7 @@ if (env.JENKINS_URL.contains('markwaite.net')) {
       // Test Java 11 with a recent LTS, Java 17 even more recent
       configurations: [
         [platform: 'linux',   jdk: '11'], // Linux first for coverage report on ci.jenkins.io
-        [platform: 'windows', jdk: '17', jenkins: '2.400'],
+        [platform: 'windows', jdk: '17', jenkins: '2.407'],
       ]
     )
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.compatibleSinceVersion>5.0</hpi.compatibleSinceVersion>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.version>2.375.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <linkXRef>false</linkXRef>
     <!-- Plugin intentionally does not deliver javadoc. -->
     <!-- No API's intended to be used, none should be called from outside. -->
@@ -62,7 +62,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.375.x</artifactId>
+        <artifactId>bom-2.387.x</artifactId>
         <version>2102.v854b_fec19c92</version>
         <type>pom</type>
         <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <version>2133.v2e6c00fe4d61</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

- Test Jenkins 2.407 on ci.jenkins.io
- Require Jenkins 2.387.3 or newer
- Use plugin BOM 2133.v2e6c00fe4d61

### Testing done

Verified plugin tests run successfully on Linux Java 11 with Jenkins 2.387.3 as minimum Jenkins version.  Will rely on ci.jenkins.io to verify Windows with Java 17 and Jenkins 2.407.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
