### PR TITLE
Add Debian 12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,6 +76,17 @@ updates:
     interval: weekly
   labels:
   - skip-changelog
+  - dependency-name: "debian"
+    update-types: ["version-update:semver-major"]
+
+- package-ecosystem: docker
+  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12"
+  schedule:
+    interval: weekly
+  labels:
+  - skip-changelog
+  - dependency-name: "debian"
+    update-types: ["version-update:semver-major"]
 
 - package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/testing"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,16 +102,6 @@ updates:
     update-types: ["version-update:semver-major"]
 
 - package-ecosystem: docker
-  directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.1"
-  schedule:
-    interval: weekly
-  labels:
-  - skip-changelog
-  ignore:
-  - dependency-name: "Dockerfile"
-    update-types: ["version-update:semver-major"]
-
-- package-ecosystem: docker
   directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.2"
   schedule:
     interval: weekly

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Clear Linux                | `clear-linux-os`   | `38990`        | `amd64`      |
 | Debian 10                  | `Debian`           | `10`           | `amd64`      | // EOL: 30 Jun 2024
 | Debian 11                  | `Debian`           | `11`           | `amd64`      | // EOL: 30 Jun 2026
+| Debian 12                  | `Debian`           | `12`           | `amd64`      | // EOL: 30 Jun 2028
 | Debian testing             | `Debian`           | `testing`      | `amd64`      |
 | Debian unstable            | `Debian`           | `unstable`     | `amd64`      |
 | Fedora 37                  | `Fedora`           | `37`           | `amd64`      | // EOL: 15 Dec 2023

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:bookworm-20230522-slim
+RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/lsb_release-a
@@ -1,0 +1,5 @@
+No LSB modules are available.
+Distributor ID:	Debian
+Description:	Debian GNU/Linux 12 (bookworm)
+Release:	12
+Codename:	bookworm

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.1/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.1/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.1.0-1817


### PR DESCRIPTION
## Add Debian 12 to documentation and test data

Debian 12 ("bookworm") released June 10, 2023.  Runs very well.

- Do not track UBI 9.1 container updates
- Add Debian 12 to documentation and test data

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Test data and documentation
