### PR TITLE
Test with Java 17 and 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,11 +40,10 @@ if (env.JENKINS_URL.contains('markwaite.net')) {
       useContainerAgent: true,
       // Show failures on all configurations
       failFast: false,
-      // Test Java 11, 17, and 21
+      // Test Java 17 and 21
       configurations: [
-        [platform: 'linux',   jdk: '17'], // Linux first for coverage report on ci.jenkins.io
-        [platform: 'linux',   jdk: '21', jenkins: '2.414'],
-        [platform: 'windows', jdk: '11'],
+        [platform: 'linux',   jdk: '21'], // Linux first for coverage report on ci.jenkins.io
+        [platform: 'windows', jdk: '17'],
       ]
     )
 }


### PR DESCRIPTION
## Test with Java 17 and 21

Reduce CI costs by testing Java 17 on Windows and Java 21 on Linux.  Accept the risk that Java 11 regression might be undetected.

### Testing done

No additional tests needed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
