### PR TITLE
Use Jenkinsfile from plugin archetype

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,12 +2,13 @@
 
 import java.util.Collections
 
-// Valid Jenkins versions for markwaite.net test
-def testJenkinsVersions = [ '2.387.3', '2.401.3', '2.414', '2.415', '2.416', '2.417', '2.418' ]
-Collections.shuffle(testJenkinsVersions)
+if (env.JENKINS_URL.contains('markwaite.net')) {
+    // Valid Jenkins versions for markwaite.net test
+    def testJenkinsVersions = [ '2.387.3', '2.401.3', '2.414.2', '2.416', '2.417', '2.418', '2.419', '2.420', '2.421', '2.423', '2.424' ]
+    Collections.shuffle(testJenkinsVersions)
 
-// build with randomized Jenkins versions
-subsetConfiguration = [
+    // build with randomized Jenkins versions
+    subsetConfiguration = [
 
                         // Intel Linux is labeled as 'linux' for legacy reasons
                         // Linux first for coverage report on ci.jenkins.io
@@ -27,23 +28,20 @@ subsetConfiguration = [
                         [ jdk: 17, platform: 's390x',    jenkins: testJenkinsVersions[5] ],
                       ]
 
-if (env.JENKINS_URL.contains('markwaite.net')) {
     // Use advanced buildPlugin on markwaite.net
     buildPlugin(configurations: subsetConfiguration, failFast: false, forkCount: '1C')
-} else {
-    // Use simple buildPlugin elsewhere
-    /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-    buildPlugin(
-      // Run a JVM per core in tests
-      forkCount: '1C',
-      // Container agents start faster and are easier to administer
-      useContainerAgent: true,
-      // Show failures on all configurations
-      failFast: false,
-      // Test Java 17 and 21
-      configurations: [
-        [platform: 'linux',   jdk: 21], // Linux first for coverage report on ci.jenkins.io
-        [platform: 'windows', jdk: 17],
-      ]
-    )
+    return
 }
+
+// Use simple buildPlugin elsewhere
+
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])


### PR DESCRIPTION
## Use Jenkinsfile from plugin archetype

Use the Jenkinsfile from the plugin archetype in order to reduce differences throughout the Jenkins organization.

The Jenkinsfile from the plugin archetype is extended to run tests in parallel in order to reduce the time and cost of tests.

https://github.com/jenkinsci/archetypes/issues/650 describes the alternatives for Jenkinsfile configurations.

### Testing done

No additional tests needed.  Pull request will be verified by ci.jenkins.io .

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
