### PR TITLE
Silence Java 21 compiler warning in constructor

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformLabelerGlobalConfiguration.java
@@ -20,6 +20,7 @@ public class PlatformLabelerGlobalConfiguration extends GlobalConfiguration {
     @SuppressFBWarnings(
             value = "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR",
             justification = "GlobalConfiguration does not depend on initialization of this object")
+    @SuppressWarnings("this-escape") // Java 21 version of spotbugs warning
     public PlatformLabelerGlobalConfiguration() {
         load();
         if (labelConfig == null) {


### PR DESCRIPTION
## Silence Java 21 compiler warning in constructor

GlobalConfiguration does not depend on initialization of this object

Same suppression as was used already for spotbugs

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Chore - keep compilation free of warnings
