### PR TITLE
Remove Alpine 3.15 - end of life

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,17 +40,6 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Maintain dependencies for Alpine 3.15
-  - package-ecosystem: "docker"
-    directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.10"
-    ignore:
-    - dependency-name: "alpine"
-      update-types: ["version-update:semver-minor"]
-    labels:
-    - "skip-changelog"
-    schedule:
-      interval: "weekly"
-
   # Maintain dependencies for Alpine 3.16
   - package-ecosystem: "docker"
     directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.16.7"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alibaba Linux 3            | `AlibabaCloud`     | `3`            | `amd64`      | // EOL: 30 Apr 2031
 | Alma Linux 8               | `AlmaLinux`        | `8.8`          | `amd64`      | // EOL: 31 Mar 2029
 | Alma Linux 9               | `AlmaLinux`        | `9.2`          | `amd64`      | // EOL: 31 May 2032
-| Alpine 3.15                | `Alpine`           | `3.15.9`       | `amd64`      | // EOL: 01 Nov 2023
 | Alpine 3.16                | `Alpine`           | `3.16.6`       | `amd64`      | // EOL: 01 May 2024
 | Alpine 3.17                | `Alpine`           | `3.17.4`       | `amd64`      | // EOL: 01 Nov 2024
 | Alpine 3.18                | `Alpine`           | `3.18.4`       | `amd64`      | // EOL: 01 May 2025

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -130,7 +130,6 @@ public class PlatformDetailsTest {
         "Windows 10", "alpine", "centos", "debian", "fedora", "freebsd", "macos", "raspbian", "ubuntu"
     };
     private final String[] versions = {
-        "3.15.7",
         "3.16.4",
         "3.17.2",
         "3.18.4",

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.10/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.10/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.15.10

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.10/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.15.10/os-release
@@ -1,6 +1,0 @@
-NAME="Alpine Linux"
-ID=alpine
-VERSION_ID=3.15.10
-PRETTY_NAME="Alpine Linux v3.15"
-HOME_URL="https://alpinelinux.org/"
-BUG_REPORT_URL="https://bugs.alpinelinux.org/"


### PR DESCRIPTION
## Remove Alpine 3.15 - end of life

Alpine 3.15 end of life was 1 Nov 2023

The Jenkins project does not support operating systems after the operating system provider has stopped public support.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Removal of an operating system
