### PR TITLE
Drop Red Hat Enterprise Linux 7 and derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ On Windows computers, the plugin assigns a label based on the Windows feature up
 Feature update labels use a two digit year and a two digit month representation.
 Common values for Windows feature update are `1809`, `1903`, `2009`, and `2109`.
 
-On Linux computers, the plugin uses the output of the [`lsb_release`](https://linux.die.net/man/1/lsb_release) command.
+On Linux computers, the plugin uses the output of the [`lsb_release`](https://linux.die.net/man/1/lsb_release) command if the command is available.
 
 If `lsb_release` is not installed, labels on Linux agents will be guessed based on values in `/etc/os-release`.
 Red Hat Linux 9 and its derivatives intentionally do not delivery `lsb_release`.
 
-Red Hat Linux and Scientific Linux agents have another fallback based on `/etc/redhat-release`.
+Red Hat Linux agents have another fallback based on `/etc/redhat-release`.
 
 Agents with an older version of SuSE Linux will fallback to `/etc/SuSE-release`. Older versions of this plugin might return "sles" or "SUSE LINUX" as OS name.
 This has been unified to "SUSE" as this is the lsb_release ID since 'SLES 12 SP2'.

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -347,8 +347,6 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         PREFERRED_LINUX_OS_NAMES.put("rhel", "RedHatEnterprise");
         PREFERRED_LINUX_OS_NAMES.put("sles", "SUSE");
         PREFERRED_LINUX_OS_NAMES.put("SUSE Linux Enterprise Server", "SUSE");
-        PREFERRED_LINUX_OS_NAMES.put("Scientific Linux", "Scientific");
-        PREFERRED_LINUX_OS_NAMES.put("scientific", "Scientific");
         PREFERRED_LINUX_OS_NAMES.put("ubuntu", "Ubuntu");
     }
 

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskLsbReleaseTest.java
@@ -112,9 +112,6 @@ public class PlatformDetailsTaskLsbReleaseTest {
         if (filename.contains("ubuntu")) {
             return "Ubuntu";
         }
-        if (filename.contains("scientific")) {
-            return "Scientific";
-        }
         if (filename.contains("sles")) {
             return "SUSE";
         }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskReleaseTest.java
@@ -136,9 +136,6 @@ public class PlatformDetailsTaskReleaseTest {
         if (filename.contains("ubuntu")) {
             return "Ubuntu";
         }
-        if (filename.contains("scientific")) {
-            return "Scientific";
-        }
         if (filename.contains("sles")) {
             return "SUSE";
         }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskTest.java
@@ -272,8 +272,8 @@ public class PlatformDetailsTaskTest {
         String version = platformDetailsTask.getReleaseIdentifier("VERSION_ID");
         /* Check that the version string returned by getReleaseIdentifier
          * is at least at the beginning of one of the detail values. Allow
-         * Debian 10 and CentOS 7 to report their base version
-         * in the /etc/os-release file without reporting their incremental
+         * Debian 10 to report its base version
+         * in the /etc/os-release file without reporting the incremental
          * version.
          *
          * If Debian unstable is in a freeze, then /etc/os-release


### PR DESCRIPTION
## Drop RHEL 7 and derivatives

Scientific Linux is completely gone

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [ ] I have interactively tested my changes

## Types of changes

- [x] Breaking change (Removes support for Red Hat Enterprise Linux 7 and its derivatives)
