### PR TITLE
Test Windows 11, Windows Server, and macOS static strings

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -28,6 +28,22 @@ public class PlatformDetailsTaskStaticStringTest {
      */
     public static Stream<Object[]> generateTestParameters() {
         Collection<Object[]> data = Arrays.asList(new Object[][] {
+            /** Windows 11 */
+            {"Windows 11", "aarch64", "10.0"},
+            {"Windows 11", "amd64", "10.0"},
+
+            /** Windows Server checks that should include version number */
+            {"Windows Server 2016", "amd64", "10.0"},
+            {"Windows Server 2019", "amd64", "10.0"},
+            {"Windows Server 2022", "amd64", "10.0"},
+
+            /** Windows Server checks that should not include version number */
+            {"Windows Server 2012", "amd64", "8.0"},
+
+            /** Mac OS X */
+            {"Mac OS X", "aarch64", "10.16"},
+            {"Mac OS X", "amd64", "10.16"},
+
             /** General cases for operating system names in platformlabeler-1.1 */
             {"mac", "amd64", "11.0"}, // macOS
             {"Solaris", "amd64", "11.3"}, // Solaris

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -117,6 +117,11 @@ public class PlatformDetailsTaskStaticStringTest {
 
     private static String computeExpectedArch(String name, String arch) {
         if (!isWindows() || !name.startsWith("Windows")) {
+            // Trust the passed value for non-Windows systems
+            return arch;
+        }
+        if (arch != "amd64" && arch != "x86") {
+            // Trust the passed value for non-Intel architectures
             return arch;
         }
         final String env1 = System.getenv("PROCESSOR_ARCHITECTURE");


### PR DESCRIPTION
## Test Windows 11, Windows Server, and macOS static strings

The cases can be tested with static strings, so no reason to skip those tests.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Tests
