### PR TITLE
Annotate PlatformDetails methods for spotbugs

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -1,5 +1,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Serializable;
 
 /** Stores the platform details of a node. */
@@ -23,7 +25,7 @@ public class PlatformDetails implements Serializable {
      * @param version version of operating system, as in 9.1, 14.04, etc.
      */
     @Deprecated
-    public PlatformDetails(String name, String architecture, String version) {
+    public PlatformDetails(@NonNull String name, @NonNull String architecture, @NonNull String version) {
         this(name, architecture, version, null);
     }
 
@@ -36,7 +38,11 @@ public class PlatformDetails implements Serializable {
      * @param windowsFeatureUpdate windows feature update version string, as in 1809, 1903, 2009,
      *     2103, etc.
      */
-    public PlatformDetails(String name, String architecture, String version, String windowsFeatureUpdate) {
+    public PlatformDetails(
+            @NonNull String name,
+            @NonNull String architecture,
+            @NonNull String version,
+            @CheckForNull String windowsFeatureUpdate) {
         this.name = name;
         this.architecture = architecture;
         this.version = version;
@@ -50,30 +56,37 @@ public class PlatformDetails implements Serializable {
         this.windowsFeatureUpdate = featureUpdate;
     }
 
+    @NonNull
     public String getName() {
         return name;
     }
 
+    @NonNull
     public String getArchitecture() {
         return architecture;
     }
 
+    @NonNull
     public String getVersion() {
         return version;
     }
 
+    @NonNull
     public String getArchitectureNameVersion() {
         return architectureNameVersion;
     }
 
+    @NonNull
     public String getArchitectureName() {
         return architectureName;
     }
 
+    @NonNull
     public String getNameVersion() {
         return nameVersion;
     }
 
+    @CheckForNull
     public String getWindowsFeatureUpdate() {
         return windowsFeatureUpdate;
     }


### PR DESCRIPTION
## Annotate PlatformDetails methods for spotbugs

First three constructor arguments must be non-null otherwise they would report a null pointer exception.  Fourth parameter allows null  because it was not available in the original (deprecated) constructor.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Maintenance reduction
