### PR TITLE
Add configuration as code example to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,48 @@ The types of labels can be configured globally and per agent with the 'Automatic
 
 To reduce the set of labels defined for an agent, activate 'Automatic Platform Labels' in the Node Properties section and select the desired label types.
 
+## Configuration as code
+
+The platform labeler plugin supports configuration as code for global configuration and for agent configuration.
+Here is a global configuration example:
+
+```yaml
+unclassified:
+  platformLabelerGlobalConfiguration:
+    labelConfig:
+      architecture: true
+      architectureName: false
+      architectureNameVersion: false
+      name: true
+      nameVersion: false
+      version: true
+      windowsFeatureUpdate: false
+```
+
+Agent configuration uses a platform labeler node property like this:
+
+```yaml
+jenkins:
+  nodes:
+  - permanent:
+      launcher:
+        inbound:
+          webSocket: true
+      name: "my-windows-agent"
+      nodeProperties:
+      - platformLabeler:
+          labelConfig:
+            architecture: true
+            architectureName: false
+            architectureNameVersion: false
+            name: true
+            nameVersion: false
+            version: true
+            windowsFeatureUpdate: false
+      remoteFS: "C:\\Users\\Jenkins\\agent"
+      retentionStrategy: "always"
+```
+
 ## Report an Issue
 
 Please report issues and enhancements through the [Jenkins issue tracker](https://www.jenkins.io/participate/report-issue/redirect/#15650).


### PR DESCRIPTION
## Add configuration as code example to docs

Configuration as code has been supported for several releases.  Add documentation with examples

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] Documentation
