### PR TITLE
Create a Windows Server label with `os.name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Labels commonly include operating system name, version, architecture, and Window
 | Ubuntu 20                  | `Ubuntu`           | `20.04`        | `amd64`      | // EOL:  2 Apr 2025
 | Ubuntu 22                  | `Ubuntu`           | `22.04`        | `amd64`      | // EOL:  1 Apr 2027
 | Windows 10                 | `windows`          | `10.0`         | `amd64`      | // EOL: 14 Oct 2025
+| Windows Server 2016        | `WindowsServer2016`| `10.0`         | `amd64`      | // EOL: 12 Jan 2027
+| Windows Server 2019        | `WindowsServer2019`| `10.0`         | `amd64`      | // EOL:  9 Jan 2029
+| Windows Server 2022        | `WindowsServer2022`| `10.0`         | `amd64`      | // EOL: 14 Oct 2031
 
 ## ARM 64 bit (aarch64)
 
@@ -103,6 +106,7 @@ unclassified:
       architectureNameVersion: false
       name: true
       nameVersion: false
+      osName: true
       version: true
       windowsFeatureUpdate: false
 ```
@@ -125,6 +129,7 @@ jenkins:
             architectureNameVersion: false
             name: true
             nameVersion: false
+            osName: true
             version: true
             windowsFeatureUpdate: false
       remoteFS: "C:\\Users\\Jenkins\\agent"

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfig.java
@@ -14,6 +14,7 @@ public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
     private boolean name = true;
     private boolean version = true;
     private boolean windowsFeatureUpdate = true;
+    private boolean osName = true;
     private boolean architectureName = true;
     private boolean nameVersion = true;
     private boolean architectureNameVersion = true;
@@ -30,6 +31,7 @@ public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
             this.name = srcLabelConfig.name;
             this.version = srcLabelConfig.version;
             this.windowsFeatureUpdate = srcLabelConfig.windowsFeatureUpdate;
+            this.osName = srcLabelConfig.osName;
             this.architectureName = srcLabelConfig.architectureName;
             this.nameVersion = srcLabelConfig.nameVersion;
             this.architectureNameVersion = srcLabelConfig.architectureNameVersion;
@@ -97,6 +99,15 @@ public class LabelConfig extends AbstractDescribableImpl<LabelConfig> {
     @DataBoundSetter
     public void setWindowsFeatureUpdate(boolean includeWindowsFeatureUpdate) {
         this.windowsFeatureUpdate = includeWindowsFeatureUpdate;
+    }
+
+    public boolean isOsName() {
+        return osName;
+    }
+
+    @DataBoundSetter
+    public void setOsName(boolean osName) {
+        this.osName = osName;
     }
 
     @Extension

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -228,6 +228,10 @@ public class NodeLabelCache extends ComputerListener {
             result.add(jenkins.getLabelAtom(pp.getWindowsFeatureUpdate()));
         }
 
+        if (labelConfig.isOsName() && pp.getOsName() != null) {
+            result.add(jenkins.getLabelAtom(pp.getOsName()));
+        }
+
         return result;
     }
 

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -13,6 +13,7 @@ public class PlatformDetails implements Serializable {
     private final String architecture;
     private final String version;
     private final String windowsFeatureUpdate;
+    private final String osName;
     private final String architectureNameVersion;
     private final String architectureName;
     private final String nameVersion;
@@ -26,11 +27,11 @@ public class PlatformDetails implements Serializable {
      */
     @Deprecated
     public PlatformDetails(@NonNull String name, @NonNull String architecture, @NonNull String version) {
-        this(name, architecture, version, null);
+        this(name, architecture, version, null, null);
     }
 
     /**
-     * Platform details constructor.
+     * Platform details constructor (deprecated).
      *
      * @param name name of operating system, as in windows, debian, ubuntu, etc.
      * @param architecture hardware architecture, as in amd64, aarch64, etc.
@@ -43,6 +44,25 @@ public class PlatformDetails implements Serializable {
             @NonNull String architecture,
             @NonNull String version,
             @CheckForNull String windowsFeatureUpdate) {
+        this(name, architecture, version, windowsFeatureUpdate, null);
+    }
+
+    /**
+     * Platform details constructor.
+     *
+     * @param name name of operating system, as in windows, debian, ubuntu, etc.
+     * @param architecture hardware architecture, as in amd64, aarch64, etc.
+     * @param version version of operating system, as in 9.1, 14.04, etc.
+     * @param windowsFeatureUpdate windows feature update version string, as in 1809, 1903, 2009,
+     *     2103, etc.
+     * @param osName name of operating system as provided by the Java os.name property
+     */
+    public PlatformDetails(
+            @NonNull String name,
+            @NonNull String architecture,
+            @NonNull String version,
+            @CheckForNull String windowsFeatureUpdate,
+            @CheckForNull String osName) {
         this.name = name;
         this.architecture = architecture;
         this.version = version;
@@ -54,6 +74,10 @@ public class PlatformDetails implements Serializable {
             featureUpdate = null;
         }
         this.windowsFeatureUpdate = featureUpdate;
+        if (osName != null && osName.isEmpty()) {
+            osName = null;
+        }
+        this.osName = osName;
     }
 
     @NonNull
@@ -89,5 +113,10 @@ public class PlatformDetails implements Serializable {
     @CheckForNull
     public String getWindowsFeatureUpdate() {
         return windowsFeatureUpdate;
+    }
+
+    @CheckForNull
+    public String getOsName() {
+        return osName;
     }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -203,6 +203,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         String computedArch = arch;
         String computedVersion = version;
         String windowsFeatureUpdate = null;
+        String osName = name; // os.name Java property of agent JVM
         if (computedName.startsWith("windows")) {
             computedName = "windows";
             computedArch = checkWindows32Bit(
@@ -222,6 +223,21 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
                 if (windowsFeatureUpdate.isEmpty()) {
                     windowsFeatureUpdate = null;
                 }
+            }
+            if (osName.startsWith("Windows Server")) {
+                if (osName.contains("2022")) {
+                    osName = "WindowsServer2022";
+                } else if (osName.contains("2019")) {
+                    osName = "WindowsServer2019";
+                } else if (osName.contains("2016")) {
+                    osName = "WindowsServer2016";
+                } else {
+                    osName = "WindowsServer";
+                }
+            }
+            if (osName.startsWith("Windows 1")) {
+                // Remove spaces from osName for modern Windows desktop versions
+                osName = osName.replace(" ", "");
             }
         } else if (computedName.startsWith("linux")) {
             if (release == null) {
@@ -308,7 +324,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
             computedName = "mac";
         }
         PlatformDetails properties =
-                new PlatformDetails(computedName, computedArch, computedVersion, windowsFeatureUpdate);
+                new PlatformDetails(computedName, computedArch, computedVersion, windowsFeatureUpdate, osName);
         return properties;
     }
 

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.jelly
@@ -12,6 +12,9 @@
   <f:entry field="windowsFeatureUpdate" title="${%Generate.LabelWithWindowsFeatureUpdate}">
     <f:checkbox default="true"/>
   </f:entry>
+  <f:entry field="osName" title="${%Generate.LabelWithOsName}">
+    <f:checkbox default="true"/>
+  </f:entry>
   <f:entry field="architectureName" title="${%Generate.LabelWithOSArchitectureAndName}">
     <f:checkbox default="true"/>
   </f:entry>

--- a/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.properties
+++ b/src/main/resources/org/jvnet/hudson/plugins/platformlabeler/LabelConfig/config.properties
@@ -1,7 +1,8 @@
 Generate.LabelWithOSArchitecture=Generate label with OS architecture
 Generate.LabelWithOSName=Generate label with OS name
 Generate.LabelWithOSVersion=Generate label with OS version
-Generate.LabelWithWindowsFeatureUpdate=Generate label with Windows feature update (like 1809, 1903, 2009, or 2103)
+Generate.LabelWithWindowsFeatureUpdate=Generate label with Windows feature update (like 1607. 1809, 21H2, and 22H2)
+Generate.LabelWithOsName=Generate label with operating system name (Java property os.name)
 Generate.LabelWithOSArchitectureAndName=Generate label with OS architecture and name
 Generate.LabelWithOSNameAndVersion=Generate label with OS name and version
 Generate.LabelWithOSArchitectureNameAndVersion=Generate label with OS architecture, name, and version

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/ConfigurationTest.java
@@ -44,6 +44,7 @@ public class ConfigurationTest {
         labelConfig.setVersion(false);
         labelConfig.setNameVersion(false);
         labelConfig.setWindowsFeatureUpdate(false);
+        labelConfig.setOsName(false);
         nodeProperty.setLabelConfig(labelConfig);
         r.jenkins.getNodeProperties().add(nodeProperty);
 
@@ -66,6 +67,7 @@ public class ConfigurationTest {
         labelConfig.setName(false);
         labelConfig.setNameVersion(false);
         labelConfig.setWindowsFeatureUpdate(false);
+        labelConfig.setOsName(false);
         nodeProperty.setLabelConfig(labelConfig);
         r.jenkins.getNodeProperties().add(nodeProperty);
 
@@ -109,6 +111,7 @@ public class ConfigurationTest {
              */
             expected.add(r.jenkins.getLabelAtom(platformDetails.getWindowsFeatureUpdate()));
         }
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getOsName()));
 
         // Static labels of the agent
         expected.add(r.jenkins.getLabelAtom("agent"));
@@ -145,6 +148,7 @@ public class ConfigurationTest {
              */
             expected.add(r.jenkins.getLabelAtom(platformDetails.getWindowsFeatureUpdate()));
         }
+        expected.add(r.jenkins.getLabelAtom(platformDetails.getOsName()));
 
         Set<LabelAtom> labelsAfter = computer.getNode().getAssignedLabels();
         assertThat(labelsAfter, is(expected));
@@ -167,6 +171,7 @@ public class ConfigurationTest {
         LabelConfig labelConfig = new LabelConfig();
         labelConfig.setVersion(false);
         labelConfig.setWindowsFeatureUpdate(false);
+        labelConfig.setOsName(false);
         nodeProperty.setLabelConfig(labelConfig);
         r.jenkins.getNodeProperties().add(nodeProperty);
 
@@ -195,6 +200,7 @@ public class ConfigurationTest {
         globalLabelConfig.setVersion(false);
         globalLabelConfig.setName(false);
         globalLabelConfig.setWindowsFeatureUpdate(false);
+        globalLabelConfig.setOsName(false);
         globalLabelConfig.setArchitectureName(false);
         globalLabelConfig.setArchitectureNameVersion(false);
         globalLabelConfig.setNameVersion(false);
@@ -223,5 +229,6 @@ public class ConfigurationTest {
         assertThat(globalLabelConfigBefore.isVersion(), is(globalLabelConfigAfter.isVersion()));
         assertThat(
                 globalLabelConfigBefore.isWindowsFeatureUpdate(), is(globalLabelConfigAfter.isWindowsFeatureUpdate()));
+        assertThat(globalLabelConfigBefore.isOsName(), is(globalLabelConfigAfter.isOsName()));
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfigTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/LabelConfigTest.java
@@ -21,6 +21,7 @@ public class LabelConfigTest {
     private boolean randomIsNameVersion;
     private boolean randomIsArchitectureNameVersion;
     private boolean randomIsWindowsFeatureUpdate;
+    private boolean randomIsOsName;
 
     public LabelConfigTest() {}
 
@@ -35,6 +36,7 @@ public class LabelConfigTest {
         randomIsNameVersion = random.nextBoolean();
         randomIsArchitectureNameVersion = random.nextBoolean();
         randomIsWindowsFeatureUpdate = random.nextBoolean();
+        randomIsOsName = random.nextBoolean();
 
         randomSrcLabelConfig.setArchitecture(randomIsArchitecture);
         randomSrcLabelConfig.setName(randomIsName);
@@ -43,6 +45,7 @@ public class LabelConfigTest {
         randomSrcLabelConfig.setNameVersion(randomIsNameVersion);
         randomSrcLabelConfig.setArchitectureNameVersion(randomIsArchitectureNameVersion);
         randomSrcLabelConfig.setWindowsFeatureUpdate(randomIsWindowsFeatureUpdate);
+        randomSrcLabelConfig.setOsName(randomIsOsName);
 
         defaultConfig = new LabelConfig();
         randomConfig = new LabelConfig(randomSrcLabelConfig);
@@ -141,5 +144,17 @@ public class LabelConfigTest {
     public void testSetWindowsFeatureUpdate() {
         defaultConfig.setWindowsFeatureUpdate(!randomIsWindowsFeatureUpdate);
         assertThat(defaultConfig.isWindowsFeatureUpdate(), is(!randomIsWindowsFeatureUpdate));
+    }
+
+    @Test
+    public void testIsOsName() {
+        assertThat(defaultConfig.isOsName(), is(true));
+        assertThat(randomConfig.isOsName(), is(randomIsOsName));
+    }
+
+    @Test
+    public void testSetOsName() {
+        defaultConfig.setOsName(!randomIsOsName);
+        assertThat(defaultConfig.isOsName(), is(!randomIsOsName));
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCacheTest.java
@@ -129,6 +129,7 @@ public class NodeLabelCacheTest {
         assertThat(platformDetails.getName(), is(localDetails.getName()));
         assertThat(platformDetails.getVersion(), is(localDetails.getVersion()));
         assertThat(platformDetails.getWindowsFeatureUpdate(), is(localDetails.getWindowsFeatureUpdate()));
+        assertThat(platformDetails.getOsName(), is(localDetails.getOsName()));
     }
 
     @Test
@@ -145,6 +146,7 @@ public class NodeLabelCacheTest {
                             is(localDetails.getName()),
                             is(localDetails.getNameVersion()),
                             is(localDetails.getVersion()),
+                            is(localDetails.getOsName()),
                             is(localDetails.getWindowsFeatureUpdate())));
         }
     }

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTaskStaticStringTest.java
@@ -108,11 +108,13 @@ public class PlatformDetailsTaskStaticStringTest {
         String expectedName = computeExpectedName(name);
         String expectedArch = computeExpectedArch(name, arch);
         String expectedVersion = computeVersion(name, version);
+        String expectedOsName = computeExpectedOsName(name);
         PlatformDetailsTask details = new PlatformDetailsTask();
         PlatformDetails result = details.computeLabels(arch, name, version);
         assertThat(result.getArchitecture(), is(expectedArch));
         assertThat(result.getName(), is(expectedName));
         assertThat(result.getVersion(), is(expectedVersion));
+        assertThat(result.getOsName(), is(expectedOsName));
     }
 
     private static String computeExpectedArch(String name, String arch) {
@@ -141,6 +143,23 @@ public class PlatformDetailsTaskStaticStringTest {
             return "mac";
         }
         return name.toLowerCase(Locale.ENGLISH);
+    }
+
+    private String computeExpectedOsName(String name) {
+        if (name.startsWith("Windows Server")) {
+            if (name.contains("2022")) {
+                return "WindowsServer2022";
+            } else if (name.contains("2019")) {
+                return "WindowsServer2019";
+            } else if (name.contains("2016")) {
+                return "WindowsServer2016";
+            }
+            return "WindowsServer";
+        }
+        if (name.startsWith("Windows 1")) {
+            return name.replace(" ", "");
+        }
+        return name;
     }
 
     private String computeVersion(String name, String version) {

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -37,6 +37,7 @@ public class PlatformDetailsTest {
     private String arch;
     private String version;
     private String windowsFeatureUpdate;
+    private String osName;
     private PlatformDetails details;
 
     public PlatformDetailsTest() {}
@@ -47,7 +48,8 @@ public class PlatformDetailsTest {
         arch = randomArch();
         version = randomVersion();
         windowsFeatureUpdate = randomWindowsFeatureUpdate();
-        details = new PlatformDetails(name, arch, version, windowsFeatureUpdate);
+        osName = name;
+        details = new PlatformDetails(name, arch, version, windowsFeatureUpdate, osName);
     }
 
     @Test
@@ -108,13 +110,13 @@ public class PlatformDetailsTest {
 
     @Test
     void testGetWindowsFeatureUpdateNull() {
-        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, null);
+        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, null, osName);
         assertThat(nullInDetails.getWindowsFeatureUpdate(), is(nullValue()));
     }
 
     @Test
     void testGetWindowsFeatureUpdateEmptyString() {
-        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, "");
+        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, "", osName);
         assertThat(nullInDetails.getWindowsFeatureUpdate(), is(nullValue()));
     }
 
@@ -125,10 +127,36 @@ public class PlatformDetailsTest {
         assertThat(detailsWithoutFeatureUpdate.getWindowsFeatureUpdate(), is(nullValue()));
     }
 
+    @Test
+    void testGetOsName() {
+        assertThat(details.getOsName(), is(osName));
+    }
+
+    @Test
+    void testGetOsNameNull() {
+        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, "non-empty", null);
+        assertThat(nullInDetails.getOsName(), is(nullValue()));
+    }
+
+    @Test
+    void testGetOsNameEmptyString() {
+        PlatformDetails nullInDetails = new PlatformDetails(name, arch, version, null, "");
+        assertThat(nullInDetails.getOsName(), is(nullValue()));
+    }
+
+    @Test
+    @Deprecated
+    void testDetailsWithoutOsName() {
+        PlatformDetails detailsWithoutOsName = new PlatformDetails(name, arch, version);
+        assertThat(detailsWithoutOsName.getOsName(), is(nullValue()));
+    }
+
     private final Random random = new Random();
+
     private final String[] names = {
         "Windows 10", "alpine", "centos", "debian", "fedora", "freebsd", "macos", "raspbian", "ubuntu"
     };
+
     private final String[] versions = {
         "3.16.4",
         "3.17.2",
@@ -153,6 +181,7 @@ public class PlatformDetailsTest {
         "38",
         "39",
     };
+
     private final String[] windowsFeatureUpdates = {
         "1703", "1709", "1803", "1809", "1903", "1909", "2003", "2009", "2103", "2109", "2203"
     };


### PR DESCRIPTION
## Create a Windows Server label with `os.name`

The Jenkins agent list shows the value of the Java `os.name` property to users in the "Architecture" column.  This change adds a new label for agents based on the value in that architecture column.  It is enabled by default.

For most Linux distributions (CentOS, Debian, openSUSE, Red Hat, Ubuntu), the value will be "Linux".  FreeBSD agents will have the value "FreeBSD".  Windows agents will have a value that depends on the Windows version that is installed.  Some examples include:

* Windows11
* Windows10
* WindowsServer2016
* WindowsServer2019
* WindowsServer2023

The operating system name label can be enabled and disabled globally and can be enabled and disabled on each agent individually.

Fixes #612

Existing labels are unaffected by the addition.  Windows agents will still be labeled "windows", as controlled by the "Generate label with OS name" setting.  Debian agents will still be labeled "Debian".

Interactive testing has been performed to verify Windows and Linux agents are labeled as expected with the various configurations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
