### PR TITLE
Use spotbugs plugin 4.8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,9 @@
     <!-- No API's intended to be used, none should be called from outside. -->
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <pmdVersion>6.55.0</pmdVersion>
+    <!-- TODO: Remove when plugin pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -80,6 +81,7 @@ public class LsbRelease implements PlatformDetailsRelease {
     }
 
     /** Read file to assign distributor ID and release. Package protected for tests. */
+    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Finalizer attack not viable")
     LsbRelease(@NonNull File lsbReleaseFile) throws IOException {
         Map<String, String> newProps = new HashMap<>();
         try (FileInputStream stream = new FileInputStream(lsbReleaseFile)) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -207,7 +207,9 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         if (computedName.startsWith("windows")) {
             computedName = "windows";
             computedArch = checkWindows32Bit(
-                    computedArch, System.getenv("PROCESSOR_ARCHITECTURE"), System.getenv("PROCESSOR_ARCHITEW6432"));
+                    computedArch,
+                    System.getProperty("os.arch", PlatformDetailsTask.UNKNOWN_VALUE_STRING),
+                    System.getenv("PROCESSOR_ARCHITEW6432"));
             if (computedVersion.startsWith("4.0")) {
                 computedVersion = "nt4";
             } else if (computedVersion.startsWith("5.0")) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTask.java
@@ -193,6 +193,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
      * @throws IOException on I/O error
      */
     @NonNull
+    @SuppressFBWarnings(value = "ENV_USE_PROPERTY_INSTEAD_OF_ENV", justification = "Use env for compatibility")
     protected PlatformDetails computeLabels(
             @NonNull final String arch,
             @NonNull final String name,
@@ -207,9 +208,7 @@ class PlatformDetailsTask implements Callable<PlatformDetails, IOException> {
         if (computedName.startsWith("windows")) {
             computedName = "windows";
             computedArch = checkWindows32Bit(
-                    computedArch,
-                    System.getProperty("os.arch", PlatformDetailsTask.UNKNOWN_VALUE_STRING),
-                    System.getenv("PROCESSOR_ARCHITEW6432"));
+                    computedArch, System.getenv("PROCESSOR_ARCHITECTURE"), System.getenv("PROCESSOR_ARCHITEW6432"));
             if (computedVersion.startsWith("4.0")) {
                 computedVersion = "nt4";
             } else if (computedVersion.startsWith("5.0")) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -63,6 +64,7 @@ public class WindowsRelease implements PlatformDetailsRelease {
     }
 
     /** Read file to assign distributor ID and release. Package protected for tests. */
+    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Finalizer attack not viable")
     WindowsRelease(File windowsReleaseFile) throws IOException {
         Map<String, String> newProps = new HashMap<>();
         try (FileInputStream stream = new FileInputStream(windowsReleaseFile)) {


### PR DESCRIPTION
## Use spotbugs plugin 4.8.2.0

Suppress spotbugs warnings for known exclusions.

Add spotbugs exclusion for env var use

Intentionally used in order to retain compatibility with existing implementation.  Code is known to be non-portable and is specifically checking the platform architecture in other locations.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [x] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes

## Types of changes

- [x] Maintenance
