### PR TITLE
Omit spotbugs CT_CONSTRUCTOR_THROWS visitor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,9 @@
     <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
     <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
     <spotbugs.effort>Max</spotbugs.effort>
+    <!-- TODO: Remove when plugin pom includes this omitVisitors -->
+    <!-- https://github.com/jenkinsci/plugin-pom/pull/869 -->
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef</spotbugs.omitVisitors>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/LsbRelease.java
@@ -25,7 +25,6 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -81,7 +80,6 @@ public class LsbRelease implements PlatformDetailsRelease {
     }
 
     /** Read file to assign distributor ID and release. Package protected for tests. */
-    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Finalizer attack not viable")
     LsbRelease(@NonNull File lsbReleaseFile) throws IOException {
         Map<String, String> newProps = new HashMap<>();
         try (FileInputStream stream = new FileInputStream(lsbReleaseFile)) {

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/WindowsRelease.java
@@ -25,7 +25,6 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -64,7 +63,6 @@ public class WindowsRelease implements PlatformDetailsRelease {
     }
 
     /** Read file to assign distributor ID and release. Package protected for tests. */
-    @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Finalizer attack not viable")
     WindowsRelease(File windowsReleaseFile) throws IOException {
         Map<String, String> newProps = new HashMap<>();
         try (FileInputStream stream = new FileInputStream(windowsReleaseFile)) {


### PR DESCRIPTION
From https://github.com/jenkinsci/plugin-pom/pull/869#issuecomment-1860918407

> Discussion in spotbugs/spotbugs#2695
> https://wiki.sei.cmu.edu/confluence/display/java/OBJ11-J.+Be+wary+of+letting+constructors+throw+exceptions
> seems to relate to libraries used with SecurityManager which is dead
> and certainly does not apply to Jenkins; we do not expect untrusted code
> to be running inside the controller JVM, and it does not seem plausible
> that finalizer abuse would happen by accident.
