### PR TITLE
[JENKINS-72224] Trigger node updates when refreshing platform labels

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -144,6 +144,14 @@ public class NodeLabelCache extends ComputerListener {
             if (node != null) {
                 nodeLabels.put(node, getLabelsForNode(node));
                 node.getAssignedLabels();
+                try {
+                    // Ensure label will see the node updated when platform details are added (or updated)
+                    // This will ensure a node have the same state if we were adding labels via the UI
+                    // See JENKINS-72224
+                    Jenkins.get().updateNode(node);
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to update node during refresh of model", e);
+                }
             }
         }
     }

--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/NodeLabelCache.java
@@ -25,6 +25,7 @@
 package org.jvnet.hudson.plugins.platformlabeler;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
@@ -35,6 +36,7 @@ import hudson.remoting.Channel;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -133,6 +135,26 @@ public class NodeLabelCache extends ComputerListener {
         nodePlatformProperties.put(computer, requestComputerPlatformDetails(computer, channel));
     }
 
+    @SuppressFBWarnings(value = "CRLF_INJECTION_LOGS", justification = "CRLF not allowed in label display names")
+    private void logUpdateNodeException(Node node, IOException e) {
+        LOGGER.log(
+                Level.FINE,
+                String.format("Exception updating node '%s' during label refresh", node.getDisplayName()),
+                e);
+    }
+
+    @SuppressFBWarnings(value = "CRLF_INJECTION_LOGS", justification = "CRLF not allowed in label display names")
+    private void logUpdateNodeResult(
+            boolean result, Node node, Collection<LabelAtom> labels, Set<LabelAtom> assignedLabels) {
+        LOGGER.log(
+                Level.FINEST,
+                String.format(
+                        "Update of node '%s' %s with labels %s and assigned labels %s",
+                        node.getDisplayName(),
+                        result ? "succeeded" : "failed",
+                        Arrays.toString(labels.toArray()),
+                        Arrays.toString(assignedLabels.toArray())));
+    }
     /**
      * Update Jenkins' model so that labels for this computer are up to date.
      *
@@ -142,15 +164,18 @@ public class NodeLabelCache extends ComputerListener {
         if (computer != null) {
             Node node = computer.getNode();
             if (node != null) {
-                nodeLabels.put(node, getLabelsForNode(node));
-                node.getAssignedLabels();
+                Collection<LabelAtom> labels = getLabelsForNode(node);
+                nodeLabels.put(node, labels);
+                Set<LabelAtom> assignedLabels = node.getAssignedLabels();
                 try {
-                    // Ensure label will see the node updated when platform details are added (or updated)
-                    // This will ensure a node have the same state if we were adding labels via the UI
+                    // Save the node to ensure label will see the node updated when platform details are added (or
+                    // updated).
+                    // This will ensure a node has the same state if we were adding labels via the UI.
                     // See JENKINS-72224
-                    Jenkins.get().updateNode(node);
+                    boolean result = Jenkins.get().updateNode(node);
+                    logUpdateNodeResult(result, node, labels, assignedLabels);
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to update node during refresh of model", e);
+                    logUpdateNodeException(node, e);
                 }
             }
         }


### PR DESCRIPTION
See JENKINS-72224 for the full context

Fix of #1170 was impartial and only ensured the labels are visible to the node itself but not from a label.

Didn't added extra test but did interactive tests

Before this PR when clicking on a label of a new connected agent didn't show the node (only the built-in)

![Screenshot from 2024-07-11 16-32-57](https://github.com/jenkinsci/platformlabeler-plugin/assets/825750/106267b0-2142-4f59-9808-6e2ac2a2078f)

After this fix. When clicking on a label, the node is directly visible

![Screenshot from 2024-07-11 16-34-28](https://github.com/jenkinsci/platformlabeler-plugin/assets/825750/b8d92cf3-5c20-4cc7-b3a2-22221e9d94e4)

## Checklist

_Put an `x` in the boxes that apply. Delete items that do not apply.  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/jenkinsci/platformlabeler-plugin/blob/master/CONTRIBUTING.md) doc
- [x] I have referenced the Jira issue related to my changes in one or more commit messages
- [ ] I have added tests that verify my changes
- [x] Unit tests pass locally with my changes
- [x] I have added documentation as necessary
- [x] No spotbugs warnings were introduced with my changes
- [x] I have interactively tested my changes

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix
