### PR TITLE
Test with Alpine 3.18.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,7 +53,7 @@ updates:
 
   # Maintain dependencies for Alpine 3.18
   - package-ecosystem: "docker"
-    directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.7"
+    directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.8"
     ignore:
     - dependency-name: "Dockerfile"
       update-types: ["version-update:semver-minor"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alma Linux 8               | `AlmaLinux`        | `8.10`         | `amd64`      | // EOL: 31 Mar 2029
 | Alma Linux 9               | `AlmaLinux`        | `9.4`          | `amd64`      | // EOL: 31 May 2032
 | Alpine 3.17                | `Alpine`           | `3.17.6`       | `amd64`      | // EOL: 01 Nov 2024
-| Alpine 3.18                | `Alpine`           | `3.18.7`       | `amd64`      | // EOL: 01 May 2025
+| Alpine 3.18                | `Alpine`           | `3.18.8`       | `amd64`      | // EOL: 01 May 2025
 | Alpine 3.19                | `Alpine`           | `3.19.2`       | `amd64`      | // EOL: 01 Nov 2025
 | Alpine 3.20                | `Alpine`           | `3.20.1`       | `amd64`      | // EOL: 01 May 2026
 | Amazon Linux 2023          | `Amazon`           | `2023`         | `amd64`      | // EOL: 15 Mar 2028

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -159,7 +159,7 @@ public class PlatformDetailsTest {
 
     private final String[] versions = {
         "3.17.2",
-        "3.18.4",
+        "3.18.8",
         "3.19.1",
         "3.20.0",
         "7.9.2009",

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.7/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.7/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.18.7

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.8/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.8/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.18.8

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.8/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.8/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.18.7
+VERSION_ID=3.18.8
 PRETTY_NAME="Alpine Linux v3.18"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.17.9-3.18.8-3.19.3-released.html
announces the release of 3.18.8 that includes a fix for OpenSSL CVE
https://security.alpinelinux.org/vuln/CVE-2024-5535
