### PR TITLE
Test with Alpine 3.19.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,10 +64,10 @@ updates:
 
   # Maintain dependencies for Alpine 3.19
   - package-ecosystem: "docker"
-    directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.2"
+    directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.3"
     ignore:
     - dependency-name: "Dockerfile"
-      update-types: ["version-update:semver-minor"]
+      update-types: ["version-update:semver-patch"]
     labels:
     - "skip-changelog"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,7 +45,7 @@ updates:
     directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.17.8"
     ignore:
     - dependency-name: "alpine"
-      update-types: ["version-update:semver-minor"]
+      update-types: ["version-update:semver-patch"]
     labels:
     - "skip-changelog"
     schedule:
@@ -56,7 +56,7 @@ updates:
     directory: "src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.18.8"
     ignore:
     - dependency-name: "Dockerfile"
-      update-types: ["version-update:semver-minor"]
+      update-types: ["version-update:semver-patch"]
     labels:
     - "skip-changelog"
     schedule:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alma Linux 9               | `AlmaLinux`        | `9.4`          | `amd64`      | // EOL: 31 May 2032
 | Alpine 3.17                | `Alpine`           | `3.17.6`       | `amd64`      | // EOL: 01 Nov 2024
 | Alpine 3.18                | `Alpine`           | `3.18.7`       | `amd64`      | // EOL: 01 May 2025
-| Alpine 3.19                | `Alpine`           | `3.19.2`       | `amd64`      | // EOL: 01 Nov 2025
+| Alpine 3.19                | `Alpine`           | `3.19.3`       | `amd64`      | // EOL: 01 Nov 2025
 | Alpine 3.20                | `Alpine`           | `3.20.1`       | `amd64`      | // EOL: 01 May 2026
 | Amazon Linux 2023          | `Amazon`           | `2023`         | `amd64`      | // EOL: 15 Mar 2028
 | Debian 11                  | `Debian`           | `11`           | `amd64`      | // EOL: 30 Jun 2026

--- a/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetailsTest.java
@@ -160,7 +160,7 @@ public class PlatformDetailsTest {
     private final String[] versions = {
         "3.17.2",
         "3.18.4",
-        "3.19.1",
+        "3.19.3",
         "3.20.0",
         "7.9.2009",
         "8.8",

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.2/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.2/Dockerfile
@@ -1,1 +1,0 @@
-FROM alpine:3.19.2

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.3/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.3/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.19.3

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.3/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/alpine/3.19.3/os-release
@@ -1,6 +1,6 @@
 NAME="Alpine Linux"
 ID=alpine
-VERSION_ID=3.19.2
+VERSION_ID=3.19.3
 PRETTY_NAME="Alpine Linux v3.19"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.17.9-3.18.8-3.19.3-released.html
announces the release of 3.19.3 that includes a fix for OpenSSL CVE
https://security.alpinelinux.org/vuln/CVE-2024-5535
