### PR TITLE
Update UBI-9 to 9.5-1734495538

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.5/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.5/Dockerfile
@@ -1,1 +1,1 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5-1734081738
+FROM registry.access.redhat.com/ubi9/ubi:9.5-1734495538


### PR DESCRIPTION
## Update UBI-9 to 9.5-1734495538

Dependabot does not detect the most recent UBI-9 release.

### Testing done

None.  Rely on ci.jenkins.io

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
