### PR TITLE
Remove SUSE Enterprise Linux 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Labels commonly include operating system name, version, architecture, and Window
 | Red Hat Enterprise Linux 9 | `RedHatEnterprise` | `9.5`          | `amd64`      | // EOL: 31 May 2032
 | Rocky Linux 8              | `Rocky`            | `8.10`         | `amd64`      | // EOL: 31 May 2029
 | Rocky Linux 9              | `Rocky`            | `9.5`          | `amd64`      | // EOL: 31 May 2032
-| SLES 12                    | `SUSE`             | `12.5`         | `amd64`      | // EOL: 31 Oct 2027
 | SLES 15                    | `SUSE`             | `15`           | `amd64`      | // EOL: 31 Jul 2031
 | Ubuntu 20                  | `Ubuntu`           | `20.04`        | `amd64`      | // EOL:  2 Apr 2025
 | Ubuntu 22                  | `Ubuntu`           | `22.04`        | `amd64`      | // EOL:  1 Apr 2027
@@ -75,7 +74,7 @@ Red Hat Linux 9 and its derivatives intentionally do not deliver `lsb_release`.
 Red Hat Linux agents have another fallback based on `/etc/redhat-release`.
 
 Agents with an older version of SuSE Linux will fallback to `/etc/SuSE-release`. Older versions of this plugin might return "sles" or "SUSE LINUX" as OS name.
-This has been unified to "SUSE" as this is the lsb_release ID since 'SLES 12 SP2'.
+This has been unified to "SUSE".
 
 When `/etc/os-release` is used, less detailed labels may be provided because more specific version information is not included in the file.
 For example:


### PR DESCRIPTION
## Remove SUSE Enterprise Linux 12

End of standard support 31 Oct 2024

### Testing done

None.  Rely on ci.jenkins.io

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
