### PR TITLE
Use Debian 20251103 for all images

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:bullseye-20250811-slim
+FROM debian:bullseye-20251103-slim
 RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/12/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:bookworm-20250811-slim
+FROM debian:bookworm-20251103-slim
 RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/13/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/13/Dockerfile
@@ -1,2 +1,2 @@
-FROM debian:trixie-20250811-slim
+FROM debian:trixie-20251103-slim
 RUN apt-get update && apt-get install -y lsb-release


### PR DESCRIPTION
Dependabot configuration has not been updating the Debian container images outside of unstable and testing.  This applies a temporary workaround to update the container images.  May need to switch to updatecli for better control of the updates.

### Testing done

Confirmed that `mvn clean verify` is successful


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
