### PR TITLE
Fail the dependency update script if processor is inadequate

### DIFF
--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/generate_test_data.sh
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/generate_test_data.sh
@@ -16,6 +16,13 @@ if [ $eol_count != 0 ] ; then
         exit $eol_count
 fi
 
+# Check that the processor is new enough to do the work
+
+if docker run --rm -i -t almalinux:10.1-minimal cat /etc/os-release 2>&1 | grep -q 'Fatal glibc error'; then
+        echo Processor is too old to update test data
+        exit 1
+fi
+
 # Generate os-release test data files from operating system images
 
 # Copy /etc/os-release from the operating system into a directory


### PR DESCRIPTION
## Fail the dependency update script if processor is inadequate

My Debian testing distribution is running on a : Intel(R) Core(TM) i5-2400 CPU @ 3.10GHz and that is too old a processor for the Alma Linux container image.

### Testing done

* Confirmed that the script correctly fails on an older processor.
* Confirmed that the script correctly passes on a newer processor.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
