### PR TITLE
Update Red Hat Enterprise Linux 9 to 9.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Labels commonly include operating system name, version, architecture, and Window
 | Oracle Linux 9              | `OracleServer`     | `9.7`          | `amd64`      | // EOL: 31 May 2032
 | Oracle Linux 10             | `OracleServer`     | `10.1`         | `amd64`      | // EOL: 31 May 2035
 | Red Hat Enterprise Linux 8  | `RedHatEnterprise` | `8.10`         | `amd64`      | // EOL: 31 May 2029
-| Red Hat Enterprise Linux 9  | `RedHatEnterprise` | `9.7`          | `amd64`      | // EOL: 31 May 2032
+| Red Hat Enterprise Linux 9  | `RedHatEnterprise` | `9.8`          | `amd64`      | // EOL: 31 May 2032
 | Red Hat Enterprise Linux 10 | `RedHatEnterprise` | `10.1`         | `amd64`      | // EOL: 31 May 2035
 | Rocky Linux 8               | `Rocky`            | `8.10`         | `amd64`      | // EOL: 31 May 2029
 | Rocky Linux 9               | `Rocky`            | `9.7`          | `amd64`      | // EOL: 31 May 2032

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.7/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.7/Dockerfile
@@ -1,1 +1,0 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.7-1778576335

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.7/redhat-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.7/redhat-release
@@ -1,1 +1,0 @@
-Red Hat Enterprise Linux release 9.7 (Plow)

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.8/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.8/Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.8-1777460305

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.8/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.8/os-release
@@ -1,10 +1,10 @@
 NAME="Red Hat Enterprise Linux"
-VERSION="9.7 (Plow)"
+VERSION="9.8 (Plow)"
 ID="rhel"
 ID_LIKE="fedora"
-VERSION_ID="9.7"
+VERSION_ID="9.8"
 PLATFORM_ID="platform:el9"
-PRETTY_NAME="Red Hat Enterprise Linux 9.7 (Plow)"
+PRETTY_NAME="Red Hat Enterprise Linux 9.8 (Plow)"
 ANSI_COLOR="0;31"
 LOGO="fedora-logo-icon"
 CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
@@ -13,6 +13,6 @@ DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterpr
 BUG_REPORT_URL="https://issues.redhat.com/"
 
 REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
-REDHAT_BUGZILLA_PRODUCT_VERSION=9.7
+REDHAT_BUGZILLA_PRODUCT_VERSION=9.8
 REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
-REDHAT_SUPPORT_PRODUCT_VERSION="9.7"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.8"

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.8/redhat-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/registry.access.redhat.com/ubi9/ubi/9.8/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux release 9.8 (Plow)


### PR DESCRIPTION
## Update Red Hat Enterprise Linux 9 to 9.8

Replace ubi9/ubi:9.7-1778576335 with ubi9/ubi:9.8-1777460305

Released in the last week.  Not yet available from the derivative providers.

### Testing done

* Confirmwed that `mvn clean verify` passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
