### PR TITLE
Allow very large updates of plugin BOM version number

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,11 @@
   "separateMinorPatch": true,
   "packageRules": [
     {
+      "description": "Allow very large updates of plugin BOM",
+      "matchPackageNames": ["io.jenkins.tools.bom:bom-*"],
+      "maxMajorIncrement": 30000
+    },
+    {
       "description": "Disallow Debian major version upgrades",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["debian"],


### PR DESCRIPTION
## Allow very large updates of plugin BOM version number

Renovate includes a limit to block major version updates of more than 500 versions, but the plugin BOM updates but more than 500 versions in a few months.

Allow larger updates to the value by Renovate, accepting that the GitHub Action to close the BOM pull request will avoid merging the update.

### Testing done

None.  Will test drive in this plugin.  If this has the desired result, I'll propose an update to the root Jenkins configuration so that other plugins receive it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
