### PR TITLE
Drop Debian 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Labels commonly include operating system name, version, architecture, and Window
 | Alpine 3.24                 | `Alpine`           | `3.24`         | `amd64`      | // EOL: 01 May 2028
 | Amazon Linux 2023           | `Amazon`           | `2023`         | `amd64`      | // EOL: 15 Mar 2028
 | Azure Linux 3.0             | `AzureLinux`       | `3.0`          | `amd64`      | // EOL: 31 May 2027
-| Debian 11                   | `Debian`           | `11`           | `amd64`      | // EOL: 30 Jun 2026
 | Debian 12                   | `Debian`           | `12`           | `amd64`      | // EOL: 30 Jun 2028
 | Debian 13                   | `Debian`           | `13`           | `amd64`      | // EOL: 30 Jun 2030
 | Debian testing              | `Debian`           | `testing`      | `amd64`      |
@@ -59,7 +58,6 @@ Labels commonly include operating system name, version, architecture, and Window
 
 | Platform                    | OS Name            | Version        | Architecture |
 | --------------------------- | ------------------ | -------------- | ------------ |
-| Raspberry Pi OS 11          | `Raspbian`         | `11`           | `arm`        | // EOL: 30 Jun 2026
 | Raspberry Pi OS 12          | `Raspbian`         | `12`           | `arm`        | // EOL: 30 Jun 2028
 
 ## IBM System 390 (s390x)

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/Dockerfile
@@ -1,2 +1,0 @@
-FROM debian:11
-RUN apt-get update && apt-get install -y lsb-release

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/lsb_release-a
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/lsb_release-a
@@ -1,5 +1,0 @@
-No LSB modules are available.
-Distributor ID:	Debian
-Description:	Debian GNU/Linux 11 (bullseye)
-Release:	11
-Codename:	bullseye

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/os-release
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/debian/11/os-release
@@ -1,9 +1,0 @@
-PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
-NAME="Debian GNU/Linux"
-VERSION_ID="11"
-VERSION="11 (bullseye)"
-VERSION_CODENAME=bullseye
-ID=debian
-HOME_URL="https://www.debian.org/"
-SUPPORT_URL="https://www.debian.org/support"
-BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
## Drop Debian 11

Remove Debian 11 from the documentation and the test data.  Long term support for Debian 11 ends August 31, 2026.

Refer to https://www.debian.org/releases/

### Testing done

Confirmed that automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
