### PR TITLE
Export PlatformDetails

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
+++ b/src/main/java/org/jvnet/hudson/plugins/platformlabeler/PlatformDetails.java
@@ -4,8 +4,11 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Serial;
 import java.io.Serializable;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /** Stores the platform details of a node. */
+@ExportedBean
 public class PlatformDetails implements Serializable {
 
     @Serial
@@ -83,41 +86,49 @@ public class PlatformDetails implements Serializable {
     }
 
     @NonNull
+    @Exported
     public String getName() {
         return name;
     }
 
     @NonNull
+    @Exported
     public String getArchitecture() {
         return architecture;
     }
 
     @NonNull
+    @Exported
     public String getVersion() {
         return version;
     }
 
     @NonNull
+    @Exported
     public String getArchitectureNameVersion() {
         return architectureNameVersion;
     }
 
     @NonNull
+    @Exported
     public String getArchitectureName() {
         return architectureName;
     }
 
     @NonNull
+    @Exported
     public String getNameVersion() {
         return nameVersion;
     }
 
     @CheckForNull
+    @Exported
     public String getWindowsFeatureUpdate() {
         return windowsFeatureUpdate;
     }
 
     @CheckForNull
+    @Exported
     public String getOsName() {
         return osName;
     }


### PR DESCRIPTION
The PlatformDetails is what is used by the node monitor, I tmust be an ExportedBean so it can be serialied in the api. Without it we get an error `PlatformDetails doesn't have @ExportedBean` when accessing `/computer/<name>/api/json`

fixes #2086 

### Testing done
Manually verified accessing the api endpoint works
```
{
  "_class": "hudson.slaves.SlaveComputer",
  "actions": [],
  "assignedLabels": [
    {
      "name": "linux"
    }
  ],
  "description": "",
  "displayName": "linux",
  "executors": [
    {

    }
  ],
  "icon": "symbol-computer",
  "iconClassName": "symbol-computer",
  "idle": true,
  "jnlpAgent": false,
  "launchSupported": true,
  "loadStatistics": {
    "_class": "hudson.model.Label$1"
  },
  "manualLaunchAllowed": true,
  "monitorData": {
    "hudson.node_monitors.SwapSpaceMonitor": {
      "_class": "hudson.node_monitors.SwapSpaceMonitor$MemoryUsage2",
      "availablePhysicalMemory": 420761600,
      "availableSwapSpace": 0,
      "totalPhysicalMemory": 8306733056,
      "totalSwapSpace": 0
    },
    "hudson.node_monitors.TemporarySpaceMonitor": {
      "_class": "hudson.node_monitors.DiskSpaceMonitorDescriptor$DiskSpace",
      "timestamp": 1785603920046,
      "path": "/tmp",
      "size": 44289617920,
      "threshold": 1073741824,
      "totalSize": 67274002432,
      "warningThreshold": 2147483648
    },
    "hudson.node_monitors.DiskSpaceMonitor": {
      "_class": "hudson.node_monitors.DiskSpaceMonitorDescriptor$DiskSpace",
      "timestamp": 1785603920046,
      "path": "/data/test",
      "size": 175824789504,
      "threshold": 1073741824,
      "totalSize": 268300193792,
      "warningThreshold": 2147483648
    },
    "hudson.node_monitors.ArchitectureMonitor": "Linux (amd64)",
    "hudson.node_monitors.ResponseTimeMonitor": {
      "_class": "hudson.node_monitors.ResponseTimeMonitor$Data",
      "timestamp": 1785603918002,
      "average": 417
    },
    "org.jvnet.hudson.plugins.platformlabeler.OsVersionNodeMonitor": {
      "_class": "org.jvnet.hudson.plugins.platformlabeler.PlatformDetails",
      "architecture": "amd64",
      "architectureName": "amd64-SUSE",
      "architectureNameVersion": "amd64-SUSE-15.5",
      "name": "SUSE",
      "nameVersion": "SUSE-15.5",
      "osName": "Linux",
      "version": "15.5",
      "windowsFeatureUpdate": null
    },
    "hudson.node_monitors.ClockMonitor": {
      "_class": "hudson.util.ClockDifference",
      "diff": 135
    }
  },
  "numExecutors": 1,
  "offline": false,
  "offlineCause": null,
  "offlineCauseReason": "",
  "oneOffExecutors": [],
  "temporarilyOffline": false,
  "absoluteRemotePath": "/data/test"
}
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
