### PR TITLE
Limit Renovate updates to Amazon Linux 2023

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,13 @@
       "maxMajorIncrement": 30000
     },
     {
+      "description": "Limit Amazon Linux 2023 Dockerfile version updates",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["amazonlinux"],
+      "matchFileNames": ["**/amzn/2023/Dockerfile"],
+      "allowedVersions": "<2024"
+    },
+    {
       "description": "Disallow Debian major version upgrades",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["debian"],

--- a/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/amzn/2023/Dockerfile
+++ b/src/test/resources/org/jvnet/hudson/plugins/platformlabeler/amzn/2023/Dockerfile
@@ -1,2 +1,2 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2027.0.20260903.0
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.12.20260831.0
 # The lsb_release command is not available for Amazon Linux 2023


### PR DESCRIPTION
## Limit Renovate updates to Amazon Linux 2023

- Revert 
  - #2115
- Limit Renovate updates to Amazon Linux 2023

### Testing done

None.  Copied the format of other Renovate rules that are known to work.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
